### PR TITLE
feat(restricted-imports): added restricted import visitor and utility…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@ library modules.
 | restricted       | Restrict a package from importing another package, or subpackages or modules from another package. |
 
 
-| RULE              | STD LIB | PROJECT | FIRST PARTY | THIRD PARTY | FUTURE |
-|-------------------|---------|---------|-------------|-------------|--------|
-| std_lib_only      | X       |         |             |             | X      |
-| project_only      | X       | X       | X           |             | X      |
-| base_package_only | X       | X       |             |             | X      |
-| first_party_only  | X       |         | X           |             | X      |
-| third_party_only  | X       |         |             | X           | X      |
-| isolated          | X       |         |             | X           | X      |
+| RULE              | STD LIB | PROJECT* | FIRST PARTY | THIRD PARTY | FUTURE |
+|-------------------|---------|----------|-------------|-------------|--------|
+| std_lib_only      | X       |          |             |             | X      |
+| project_only      | X       | X        | X           |             | X      |
+| base_package_only | X       | X        |             |             | X      |
+| first_party_only  | X       |          | X           |             | X      |
+| third_party_only  | X       |          |             | X           | X      |
+| isolated          | X       |          |             | X           | X      |
 
 
-
+*Technically project imports are "First Party" imports, but in this case we want to make a distinction between the top-level package and the rest of the project.
 
 # Example Configuration
 

--- a/src/flake8_custom_import_rules/core/error_messages.py
+++ b/src/flake8_custom_import_rules/core/error_messages.py
@@ -83,3 +83,15 @@ def first_party_only_error(
         # f"which is not a first-party library."
     )
     return standard_error_message(node, error_code, custom_explanation)
+
+
+def restricted_imports_error(
+    node: ParsedNode,
+    error_code: ErrorCode,
+) -> ErrorMessage:
+    """Generate error message for restricted imports."""
+    custom_explanation = (
+        f"Using '{node.import_statement}'. Restricted package/module "
+        f"cannot be imported outside package/module."
+    )
+    return standard_error_message(node, error_code, custom_explanation)

--- a/src/flake8_custom_import_rules/core/nodes.py
+++ b/src/flake8_custom_import_rules/core/nodes.py
@@ -145,6 +145,19 @@ class DynamicStringParseSyntaxFailure:
     value: str
 
 
+@define(slots=True)
+class ParsedRestrictedImport:
+    """Parsed import statement"""
+
+    import_type: ImportType
+    module: str
+    package: str
+    package_names: list[str]
+    identifier: str
+    check_exists: bool = False
+    filename: str | None = None
+
+
 ParsedNode = (
     ParsedStraightImport
     | ParsedFromImport

--- a/src/flake8_custom_import_rules/core/restricted_import_visitor.py
+++ b/src/flake8_custom_import_rules/core/restricted_import_visitor.py
@@ -1,0 +1,87 @@
+""" Visitor for parsing restricted imports. """
+import ast
+from collections import defaultdict
+
+from attr import define
+from attr import field
+
+from flake8_custom_import_rules.utils.node_utils import get_package_names
+from flake8_custom_import_rules.utils.node_utils import root_package_name
+from flake8_custom_import_rules.utils.parse_utils import get_file_path_from_module_name
+
+
+@define(slots=True)
+class RestrictedImportVisitor(ast.NodeVisitor):
+    """Visitor for dynamic strings."""
+
+    _restricted_imports: list[str]
+    _check_module_exists: bool
+    _lines: list[str] = field(init=False)
+    _tree: ast.AST = field(init=False)
+    _package_names: list = field(factory=list)
+
+    restricted_identifiers: defaultdict[str, dict] = defaultdict(lambda: defaultdict(str))
+
+    def __attrs_post_init__(self) -> None:
+        """Initialize."""
+        self._lines = [
+            f"import {restricted_import}\n" for restricted_import in self._restricted_imports
+        ]
+        self._tree = ast.parse("".join(self._lines))
+
+    def visit_Import(self, node: ast.Import) -> None:
+        """Visit an Dynamic String Import node."""
+
+        for alias in node.names:
+            module = alias.name
+            package = root_package_name(module)
+            package_names = get_package_names(module)
+
+            self.restricted_identifiers[module].update(
+                {
+                    "module": module,
+                    "package": package,
+                    "package_names": package_names,
+                    "import_statement": ast.unparse(node),
+                    "filename": get_file_path_from_module_name(module)
+                    if self._check_module_exists
+                    else None,
+                }
+            )
+            self._package_names.extend(package_names[:-1])
+
+    # def _process_package_names(self) -> None:
+    #     """Process package names."""
+    #     for package_name in set(self._package_names):
+    #         self._package_names.append(package_name)
+
+    def get_restricted_identifiers(self) -> dict:
+        """Get the list of restricted imports."""
+        self.visit(self._tree)
+        return self.restricted_identifiers
+
+
+def get_restricted_identifiers(
+    restricted_imports: list[str] | str,
+    check_module_exists: bool = True,
+) -> dict:
+    """
+    Get restricted import node.
+
+    Parameters
+    ----------
+    restricted_imports : list[str]
+        The list of restricted imports.
+    check_module_exists : bool, optional
+        Whether to check if the module exists, by default True
+
+    Returns
+    -------
+    dict
+        The restricted import node.
+    """
+    if isinstance(restricted_imports, str):
+        restricted_imports = [restricted_imports]
+
+    visitor = RestrictedImportVisitor(restricted_imports, check_module_exists)
+    return visitor.get_restricted_identifiers()

--- a/src/flake8_custom_import_rules/defaults.py
+++ b/src/flake8_custom_import_rules/defaults.py
@@ -91,13 +91,13 @@ class Settings:
     RESTRICT_ALIASED_IMPORTS: bool = False
     RESTRICT_FUTURE_IMPORTS: bool = False
 
+    # Set Defaults for Project Import Restriction Special Cases
     RESTRICT_INIT_IMPORTS: bool = True
     RESTRICT_MAIN_IMPORTS: bool = True
     RESTRICT_TEST_IMPORTS: bool = True
     RESTRICT_CONFTEST_IMPORTS: bool = True
 
     # Set Defaults for Custom Import Rules
-
     BASE_PACKAGES: list = field(factory=list, converter=convert_to_list)
     IMPORT_RESTRICTIONS: defaultdict[str, list] = field(factory=dict, converter=convert_to_dict)
     RESTRICTED_PACKAGES: list = field(factory=list, converter=convert_to_list)
@@ -107,18 +107,6 @@ class Settings:
     FIRST_PARTY_ONLY: list = field(factory=list, converter=convert_to_list)
     PROJECT_ONLY: list = field(factory=list, converter=convert_to_list)
     BASE_PACKAGE_ONLY: list = field(factory=list, converter=convert_to_list)
-
-    _import_rules: dict = field(factory=dict)
-
-    # def __attrs_post_init__(self) -> None:
-    #     """Post init."""
-
-    @property
-    def import_rules(self) -> dict:
-        """Return the settings as a dictionary."""
-        if not self._import_rules:
-            self._import_rules = asdict(self)
-        return self._import_rules
 
     @property
     def dict(self) -> dict:

--- a/src/flake8_custom_import_rules/utils/parse_utils.py
+++ b/src/flake8_custom_import_rules/utils/parse_utils.py
@@ -139,6 +139,35 @@ def does_file_match_custom_rule(file_identifier: str, custom_rules: list[str] | 
     return check_string(file_identifier, prefix=tuple(custom_rules), delimiter=" ")
 
 
+def does_import_match_restricted_imports(
+    node_identifier: str, restricted_imports: list[str] | str | None
+) -> bool:
+    """Check if an import identifier is in a restricted import."""
+    if restricted_imports is None:
+        return False
+    restricted_imports = (
+        [restricted_imports] if isinstance(restricted_imports, str) else restricted_imports
+    )
+    return check_string(node_identifier, prefix=tuple(restricted_imports), delimiter=" ")
+
+
+def get_common_ancestors(current_packages: str, import_packages: str) -> list[str]:
+    """Get the common ancestors of two modules."""
+    return [ancestor for ancestor in import_packages if ancestor in current_packages]
+
+
+def retrieve_custom_rule_matches(identifier: str, custom_rules: list[str] | str) -> list[str]:
+    """Retrieve custom rule matches."""
+    if isinstance(custom_rules, str):
+        custom_rules = [custom_rules]
+    matches: list[str] = [
+        custom_rule_match
+        for custom_rule_match in custom_rules
+        if check_string(identifier, prefix=custom_rule_match, delimiter=" ")
+    ]
+    return matches  # max(matches, key=len)
+
+
 def parse_custom_rule(rules: list[str]) -> dict[str, list[str]]:
     """Parse custom rules."""
     return {src.strip(): dest.split(",") for rule in rules for src, dest in (rule.split(":"),)}

--- a/tests/my_base_module_test.py
+++ b/tests/my_base_module_test.py
@@ -1,23 +1,28 @@
 """ Test module included in the example repo. """
 import ast
 import os
+from textwrap import dedent
 
 import pycodestyle
 
 from flake8_custom_import_rules.core.node_visitor import CustomImportRulesVisitor
 from flake8_custom_import_rules.core.rules_checker import BaseCustomImportRulePlugin
+from flake8_custom_import_rules.utils.node_utils import is_import_restricted
 
 filename = "example_repos/my_base_module/my_base_module/package_a/module_a.py"
 # filename = "example_repos/my_base_module/my_base_module/package_c/module_c.py"
 # filename = "example_repos/my_base_module/my_base_module/module_y.py"
 # filename = "example_repos/my_base_module/my_base_module/module_z.py"
+filename = "example_repos/my_base_module/my_second_base_package/module_three.py"
 file_identifier = os.path.split(filename)[-1].split(".")[0]
 lines = pycodestyle.readlines(filename)
 tree = ast.parse("".join(lines))
 
-plugin = BaseCustomImportRulePlugin(tree=tree, filename=filename)
+plugin = BaseCustomImportRulePlugin(tree=tree, filename=filename, lines=lines)
 plugin.get_run_list()
 plugin.get_import_nodes()
+for _, _, node, _ in plugin.get_import_nodes():
+    print(node)
 
 # data = "import sys; attrs = sys.modules['attrs']"
 # tree = ast.parse(data)
@@ -25,3 +30,67 @@ plugin.get_import_nodes()
 visitor = CustomImportRulesVisitor(["my_base_module"], None)
 visitor.visit(tree)
 visitor.nodes
+
+
+COMPLEX_IMPORTS = dedent(
+    """
+    import my_second_base_package.module_one.file_one
+    import my_second_base_package.module_one.file_two
+    import my_second_base_package.module_one
+    import my_second_base_package.module_two.file_one
+    import my_second_base_package.module_two.file_two
+    import my_second_base_package.module_two
+    import my_second_base_package.file
+    import my_second_base_package
+    import base_package
+    import my_third_base_package
+
+    from my_second_base_package.module_one.file_one import A
+    from my_second_base_package.module_one.file_two import B
+    from my_second_base_package.module_one import file_one
+    from my_second_base_package.module_one import file_two
+    from my_second_base_package.module_one import C
+    from my_second_base_package.module_two import file_one
+    from my_second_base_package.module_two import file_two
+    from my_second_base_package.module_two import D
+    from my_second_base_package.file import C
+    from my_second_base_package import module_one
+    from my_second_base_package import module_two
+    from my_second_base_package import file
+    from my_second_base_package import E
+    from base_package import F
+    from my_third_base_package import G
+    """
+)
+
+restricted_imports = [
+    "my_second_base_package",
+    "my_second_base_package.module_one",
+    "my_second_base_package.module_one.file_one",
+    "my_third_base_package",
+]
+
+current_modules = [
+    "my_second_base_package.module_one.file_one",
+    "my_second_base_package.module_one.file_two",
+    "my_second_base_package.module_two.file_one",
+    "my_second_base_package.module_two.file_two",
+    "my_second_base_package.file",
+]
+
+current_module = "my_second_base_package.module_one.file_two"
+# filename = "example_repos/my_second_base_package/module_one/file_two.py"
+lines = COMPLEX_IMPORTS.split("\n")
+tree = ast.parse(COMPLEX_IMPORTS)
+
+plugin = BaseCustomImportRulePlugin(tree=tree, filename=filename, lines=lines)
+plugin.get_run_list()
+plugin.get_import_nodes()
+parsed_imports = [parsed_import for _, _, parsed_import, _ in plugin.get_import_nodes()]
+for current_module in current_modules:
+    print(f"\n\nCurrent module: {current_module}")
+    for parsed_import in parsed_imports:
+        print(
+            f"Is '{parsed_import.import_statement}' allowed in '{current_module}'? "
+            f"{is_import_restricted(parsed_import, current_module, restricted_imports)}"
+        )

--- a/tests/parse_utils_test.py
+++ b/tests/parse_utils_test.py
@@ -7,7 +7,9 @@ import pytest
 
 from flake8_custom_import_rules.utils.parse_utils import check_string
 from flake8_custom_import_rules.utils.parse_utils import does_file_match_custom_rule
+from flake8_custom_import_rules.utils.parse_utils import does_import_match_restricted_imports
 from flake8_custom_import_rules.utils.parse_utils import parse_module_string
+from flake8_custom_import_rules.utils.parse_utils import retrieve_custom_rule_matches
 
 
 @pytest.mark.parametrize(
@@ -112,9 +114,102 @@ PACKAGE_5 = ["my_base_package.package_a.mod_a"]
         ("my_base_package.package_a.mod_a", PACKAGE_5, True),
     ],
 )
-def test_does_file_match_custom_rule(file_identifier, custom_rules, expected) -> None:
+def test_does_file_match_custom_rule(
+    file_identifier: str, custom_rules: list[str], expected: bool
+) -> None:
     """Test does_file_match_custom_rule."""
     assert (
         does_file_match_custom_rule(file_identifier=file_identifier, custom_rules=custom_rules)
         == expected
+    )
+
+
+PACKAGE_6 = [
+    "my_second_base_package",
+    "my_second_base_package.module_one",
+    "my_second_base_package.module_one.file_one",
+    "my_third_base_package",
+]
+
+
+@pytest.mark.parametrize(
+    ("node_identifier", "restricted_imports", "expected"),
+    [
+        ("my_second_base_package.module_one.file_one", PACKAGE_6, True),
+        ("my_second_base_package.module_one.file_two", PACKAGE_6, True),
+        ("my_second_base_package.module_one.file_three", PACKAGE_6, True),
+        ("my_second_base_package.module_two.file_one", PACKAGE_6, True),
+        ("my_second_base_package.module_two.file_two", PACKAGE_6, True),
+        ("my_second_base_package.module_two.file_three", PACKAGE_6, True),
+        ("my_second_base_package.file", PACKAGE_6, True),
+        ("base_package.file", PACKAGE_6, False),
+        ("my_third_base_package.file", PACKAGE_6, True),
+    ],
+)
+def test_does_import_match_restricted_imports(
+    node_identifier: str, restricted_imports: list[str], expected: bool
+) -> None:
+    """Test does_import_match_restricted_imports."""
+    assert (
+        does_import_match_restricted_imports(
+            node_identifier=node_identifier, restricted_imports=restricted_imports
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("identifier", "custom_rules", "expected"),
+    [
+        (
+            "my_second_base_package.module_one.file_one",
+            PACKAGE_6,
+            [
+                "my_second_base_package",
+                "my_second_base_package.module_one",
+                "my_second_base_package.module_one.file_one",
+            ],
+        ),
+        (
+            "my_second_base_package.module_one.file_two",
+            PACKAGE_6,
+            [
+                "my_second_base_package",
+                "my_second_base_package.module_one",
+            ],
+        ),
+        (
+            "my_second_base_package.module_two.file_one",
+            PACKAGE_6,
+            [
+                "my_second_base_package",
+            ],
+        ),
+        (
+            "my_second_base_package.module_two.file_two",
+            PACKAGE_6,
+            [
+                "my_second_base_package",
+            ],
+        ),
+        (
+            "my_second_base_package.file",
+            PACKAGE_6,
+            [
+                "my_second_base_package",
+            ],
+        ),
+        (
+            "base_package.file",
+            PACKAGE_6,
+            [],
+        ),
+    ],
+)
+def test_retrieve_custom_rule_matches(
+    identifier: str, custom_rules: list[str], expected: str
+) -> None:
+    """Test retrieve_custom_rule_matches."""
+    assert (
+        retrieve_custom_rule_matches(identifier=identifier, custom_rules=custom_rules) == expected
     )

--- a/tests/test_cases/custom_import_rules/restricted_package_test.py
+++ b/tests/test_cases/custom_import_rules/restricted_package_test.py
@@ -3,69 +3,89 @@
 To run this test file only:
 poetry run python -m pytest -vvvrca tests/test_cases/custom_import_rules/restricted_package_test.py
 """
-# import pycodestyle
-# import pytest
-# from flake8.utils import normalize_path
-#
-# from flake8_custom_import_rules.defaults import Settings
-# from flake8_custom_import_rules.utils.node_utils import root_package_name
-# from flake8_custom_import_rules.utils.parse_utils import get_module_name_from_filename
-#
-# CIR106 = "CIR106 Restricted package import."
-# CIR107 = "CIR107 Restricted module import."
-# MODULE_A_ERRORS = {}
-#
-#
-# @pytest.mark.parametrize(
-#     ("test_case", "restricted_imports", "expected"),
-#     [
-#         (
-#             "example_repos/my_base_module/my_base_module/package_a/module_a.py",
-#             ["my_base_module"],
-#             MODULE_A_ERRORS,
-#         ),
-#         (
-#             "example_repos/my_base_module/my_base_module/package_a/module_a.py",
-#             ["my_base_module.package_a"],
-#             MODULE_A_ERRORS,
-#         ),
-#     ],
-# )
-# def test_restricted_imports(
-#     test_case: str,
-#     restricted_imports: list[str],
-#     expected: set,
-#     get_flake8_linter_results: callable,
-# ) -> None:
-#     """Test restricted imports."""
-#     filename = normalize_path(test_case)
-#     lines = pycodestyle.readlines(filename)
-#     identifier = get_module_name_from_filename(filename)
-#     base_packages = root_package_name(identifier)
-#     options = {
-#         "base_packages": [base_packages],
-#         "checker_settings": Settings(
-#             **{
-#                 "RESTRICTED_PACKAGES": restricted_imports,
-#                 "RESTRICT_DYNAMIC_IMPORTS": False,
-#                 "RESTRICT_LOCAL_IMPORTS": False,
-#                 "RESTRICT_RELATIVE_IMPORTS": False,
-#             }
-#         ),
-#     }
-#     actual = get_flake8_linter_results(
-#         s="".join(lines), options=options, delimiter="\n", filename=filename
-#     )
-#     assert actual == expected, sorted(actual)
-#
-#
-# def test_restricted_import_settings_do_not_error(
-#     valid_custom_import_rules_imports: str,
-#     get_flake8_linter_results: callable,
-# ) -> None:
-#     """Test restricted imports do not have an effect on regular import methods."""
-#     options = {"checker_settings": Settings(**{"RESTRICTED_PACKAGES": []})}
-#     actual = get_flake8_linter_results(
-#         s=valid_custom_import_rules_imports, options=options, delimiter="\n"
-#     )
-#     assert actual == set()
+import pycodestyle
+import pytest
+from flake8.utils import normalize_path
+
+from flake8_custom_import_rules.defaults import Settings
+from flake8_custom_import_rules.utils.node_utils import root_package_name
+from flake8_custom_import_rules.utils.parse_utils import get_module_name_from_filename
+
+CIR106 = "CIR106 Restricted package import."
+CIR107 = "CIR107 Restricted module import."
+MODULE_A_ERRORS = set()
+
+
+@pytest.mark.parametrize(
+    ("test_case", "restricted_packages", "expected"),
+    [
+        # (
+        #     "example_repos/my_base_module/my_second_base_package/module_three.py",
+        #     ["my_second_base_package"],
+        #     set(),
+        # ),
+        (
+            "example_repos/my_base_module/my_second_base_package/module_three.py",
+            ["my_second_base_package.module_three"],
+            set(),
+        ),
+        # (
+        #     "example_repos/my_base_module/my_second_base_package/module_three.py",
+        #     ["my_second_base_package.module_one", "my_second_base_package.module_two"],
+        #     set(),
+        # ),
+        # (
+        #     "example_repos/my_base_module/my_second_base_package/module_three.py",
+        #     ["my_second_base_package.module_one"],
+        #     set(),
+        # ),
+        # (
+        #     "example_repos/my_base_module/my_second_base_package/module_three.py",
+        #     ["my_base_module"],
+        #     set(),
+        # ),
+        # (
+        #     "example_repos/my_base_module/my_second_base_package/module_three.py",
+        #     ["my_base_module.module_x"],
+        #     set(),
+        # ),
+    ],
+)
+def test_restricted_packages(
+    test_case: str,
+    restricted_packages: list[str],
+    expected: set,
+    get_flake8_linter_results: callable,
+) -> None:
+    """Test restricted imports."""
+    filename = normalize_path(test_case)
+    lines = pycodestyle.readlines(filename)
+    identifier = get_module_name_from_filename(filename)
+    root_package_name(identifier)
+    options = {
+        "base_packages": ["my_second_base_package"],
+        "checker_settings": Settings(
+            **{
+                "RESTRICTED_PACKAGES": restricted_packages,
+                "RESTRICT_DYNAMIC_IMPORTS": False,
+                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_RELATIVE_IMPORTS": False,
+            }
+        ),
+    }
+    actual = get_flake8_linter_results(
+        s="".join(lines), options=options, delimiter="\n", filename=filename
+    )
+    assert actual == expected, sorted(actual)
+
+
+def test_restricted_import_settings_do_not_error(
+    valid_custom_import_rules_imports: str,
+    get_flake8_linter_results: callable,
+) -> None:
+    """Test restricted imports do not have an effect on regular import methods."""
+    options = {"checker_settings": Settings(**{"RESTRICTED_PACKAGES": []})}
+    actual = get_flake8_linter_results(
+        s=valid_custom_import_rules_imports, options=options, delimiter="\n"
+    )
+    assert actual == set()


### PR DESCRIPTION
… functions

Approach to determine which imports are allowed:

Extract the identifier attribute from the parsed import statement.
For each restricted import, check if the import identifier starts with the restricted import.
If it does, check if the current module identifier also starts with the restricted import. If so, the import is allowed (return True). If not, the import is not allowed (return False).
If the import identifier does not start with any of the restricted imports, the import is allowed (return True).
This approach leverages the attributes provided by the ParsedStraightImport and ParsedFromImport classes and should be more efficient and accurate than manually parsing the import statement. Please implement this in your environment with the actual classes and let me know how it works.

## RATIONALE

A short description of the changes in this pull request. If the pull request is
related to an open issue, mention it here.

## CHANGES
- Added restricted import visitor
- Corresponding utility functions
- Add and update corresponding tests
- 
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
