### PR TITLE
feat(checker): added support for restricted imports

### DIFF
--- a/src/flake8_custom_import_rules/core/import_rules.py
+++ b/src/flake8_custom_import_rules/core/import_rules.py
@@ -123,6 +123,7 @@ class CustomImportRules:
 
         self.restricted_packages = self.checker_settings.RESTRICTED_PACKAGES
         self.file_in_restricted_packages = get_file_matches_custom_rule("RESTRICTED_PACKAGES")(self)
+
         print(f"Restricted packages: {self.restricted_packages}")
         logger.info(f"Restricted packages: {self.restricted_packages}")
 

--- a/src/flake8_custom_import_rules/core/node_visitor.py
+++ b/src/flake8_custom_import_rules/core/node_visitor.py
@@ -47,8 +47,6 @@ class CustomImportRulesVisitor(ast.NodeVisitor):
         The resulting nodes from the visitor
     dynamic_nodes : defaultdict[str, list]
         The resulting nodes from the visitor that parses dynamic strings
-    package_root : list[str]
-        The absolute path to the package root
     file_path : Path | None
         File path equal to Path(filename) if filename is not empty or None,
         otherwise None
@@ -73,7 +71,6 @@ class CustomImportRulesVisitor(ast.NodeVisitor):
     filename: str | None = None
     nodes: list = field(factory=list)
     dynamic_nodes: defaultdict[str, list] = defaultdict(list)
-    package_root: list[str] = field(factory=list)
     file_path: Path | None = None
     resolve_local_imports: bool | None = field(default=False)
     identifiers: defaultdict[str, dict] = defaultdict(lambda: defaultdict(str))
@@ -117,8 +114,9 @@ class CustomImportRulesVisitor(ast.NodeVisitor):
 
     def _resolve_local_import(self, module: str, node_level: int) -> Path | None:
         """Resolve a local import."""
-        parent = self.file_path.parents[node_level - 1] if self.file_path else None
-        return parent / f"{module}.py" if parent else None
+        # parent = self.file_path.parents[node_level - 1] if self.file_path else None
+        # return parent / f"{module}.py" if parent else None
+        raise NotImplementedError("This method is not implemented yet.")
 
     def resolve_relative_import(self, relative_import: str) -> str:
         """Resolve a relative import to its absolute form."""

--- a/src/flake8_custom_import_rules/flake8_plugin.py
+++ b/src/flake8_custom_import_rules/flake8_plugin.py
@@ -117,6 +117,7 @@ class Plugin(CustomImportRulesChecker):
                 options[option_key] = option_value
 
         parsed_options: dict = {
+            "restricted_packages": options["RESTRICTED_PACKAGES"],
             "base_packages": options["BASE_PACKAGES"],
             "checker_settings": Settings(**options),
             "test_env": False,

--- a/tests/test_cases/custom_import_rules/restricted_package_test.py
+++ b/tests/test_cases/custom_import_rules/restricted_package_test.py
@@ -41,6 +41,11 @@ MODULE_A_ERRORS = set()
         # ),
         # (
         #     "example_repos/my_base_module/my_second_base_package/module_three.py",
+        #     ["my_second_base_package.module_one", "my_second_base_package"],
+        #     set(),
+        # ),
+        # (
+        #     "example_repos/my_base_module/my_second_base_package/module_three.py",
         #     ["my_base_module"],
         #     set(),
         # ),


### PR DESCRIPTION
## RATIONALE

A short description of the changes in this pull request. If the pull request is
related to an open issue, mention it here.

## CHANGES
Add to checker
```python
    @property
    def restricted_identifiers(self) -> dict:
        """Return the restricted identifiers."""
        return get_restricted_identifiers(
            restricted_imports=self.options.get("restricted_imports", []),
            check_module_exists=True,
        )
```

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
