### PR TITLE
refactor(defaults): update help strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ Restricted imports can be configured in two ways:
   Example: Prevent 'package_A' from importing 'package_B' or any of its
   subpackages or modules.
 - By module: Restrict a module from importing specific modules.
-  Example: Prevent 'module_A' from importing 'module_B'.
+  Example: Prevent 'package_A.module_A' from importing 'package_B.module_B'.
 
 Restricted packages: Specify a list of packages that are not permitted to be
 imported or used by other packages or modules within your base package. This
 helps maintain a clear separation between high-level and low-level packages.
 
-Example: Disallow importing 'low_level_package' into 'high_level_package'.
+Example: Restrict importing 'lower_level_package' into 'higher_level_package'.
 
 Isolated packages: Define a list of packages that cannot import from any other
 packages within your base package. This ensures that certain packages remain
@@ -87,14 +87,15 @@ library modules.
 
 ## Custom Import Rules
 
-| Rule             | Description                                                                                   |
-|------------------|-----------------------------------------------------------------------------------------------|
-| std_lib_only     | Allow a package to import only from the Python standard library.                              |
-| project_only     | Allow a package to import only from the local package.                                        |
-| first_party_only | Allow a package to import only from the local package and the project's top-level package.    |
-| third_party_only | Allow a package to import only from third-party libraries.                                    |
-| isolated         | Make a package isolated, so it cannot import from any other packages within the base package. |
-| restricted       | Restrict a package from importing another package, or modules from another package.           |
+| Rule              | Description                                                                                   |
+|-------------------|-----------------------------------------------------------------------------------------------|
+| std_lib_only      | Restrict package to import only from the Python standard library.                             |
+| project_only      | Restrict package to import only from the local package and the project's top-level package.   |
+| base_package_only | Restrict package to import only from the project's top-level package only.                    |
+| first_party_only  | Restrict package to import only from the local packages only.                                 |
+| third_party_only  | Restrict package to import only from third-party libraries.                                   |
+| isolated          | Make a package isolated, so it cannot import from any other packages within the base package. |
+| restricted        | Restrict a package from importing another package, or modules from another package.           |
 
 
 | RULE              | STD LIB | PROJECT* | FIRST PARTY | THIRD PARTY | FUTURE |

--- a/src/flake8_custom_import_rules/defaults.py
+++ b/src/flake8_custom_import_rules/defaults.py
@@ -47,7 +47,7 @@ STANDARD_PROJECT_LEVEL_RESTRICTION_KEYS = [
 ]
 
 CUSTOM_IMPORT_RULES = [
-    # "BASE_PACKAGES",
+    "BASE_PACKAGES",
     "IMPORT_RESTRICTIONS",
     "RESTRICTED_PACKAGES",
     "ISOLATED_MODULES",
@@ -164,6 +164,88 @@ class Settings:
 DEFAULT_CHECKER_SETTINGS = Settings()
 
 
+HELP_STRINGS = {
+    "base-packages": (
+        "This option allows you to define the main packages in your project. "
+        "These packages are considered first-party and are generally the ones "
+        "you are developing in your project. Import names to consider as "
+        "first party modules (i.e., the name of your package or library). "
+        "For example, if you're building a library named 'my_library', you "
+        "would include 'my_library' as a base package. If this option is not "
+        "set, some functionality will be disabled."
+    ),
+    "import-restrictions": (
+        "This option allows you to restrict specific import capabilities for "
+        "packages. You can define a list of packages that are restricted from "
+        "importing certain packages or modules within your base package. "
+        "This option allows you to define the main packages in your project."
+    ),
+    "restricted-packages": (
+        "This option lets you specify a list of packages that are not "
+        "permitted to be imported or used by other packages or modules within "
+        "your base package. This helps maintain a clear separation between "
+        "high-level and low-level packages."
+    ),
+    "std-lib-only": (
+        "This option allows you to specify a set of packages that can only "
+        "import from third-party libraries. This can be useful to limit the "
+        "dependencies of a package to external libraries only."
+    ),
+    "project-only": (
+        "This option allows you to restrict a package to import only from the "
+        "local package and the project's top-level package. This will treat "
+        "the packages defined in `--base-packages` as the top-level package."
+    ),
+    "base-package-only": (
+        "This option lets you restrict a package to import only from the "
+        "project's top-level package. This will treat the first package "
+        "defined in base_packages as the top-level package."
+    ),
+    "first-party-only": (
+        "This option enables you to specify a set of packages that can only "
+        "import from the local packages (i.e., the packages defined in your "
+        "base packages)."
+    ),
+    "third-party-only": (
+        "Define packages that should only import from third-party libraries. "
+        "This rule helps maintain a clear dependency scope for the specified "
+        "packages."
+    ),
+    "isolated-modules": (
+        "This option allows you to define a list of modules that cannot import "
+        "from any other modules within your base package. This ensures that "
+        "certain modules remain standalone and do not introduce unwanted "
+        "dependencies."
+    ),
+    # "top-level-only-imports": If set to True, only top-level imports are
+    # permitted in the project. (default: True)
+    # "restrict-relative-imports": If set to True, relative imports for the
+    # project are disabled. (default: True)
+    # restrict-local-imports RESTRICT_LOCAL_IMPORTS: If set to True, local
+    # imports for the project are disabled. (default: True)
+    # restrict-conditional-imports RESTRICT_CONDITIONAL_IMPORTS: If set to
+    # True, conditional imports for the project are disabled. (default: False)
+    # restrict-dynamic-imports RESTRICT_DYNAMIC_IMPORTS: If set to True,
+    # dynamic imports for the project are disabled. (default: True)
+    # restrict-private-imports RESTRICT_PRIVATE_IMPORTS: If set to True,
+    # private imports for the project are disabled. (default: True)
+    # restrict-wildcard-imports RESTRICT_WILDCARD_IMPORTS: If set to True,
+    # wildcard imports for the project are disabled. (default: True)
+    # restrict-aliased-imports RESTRICT_ALIASED_IMPORTS: If set to True,
+    # aliased imports for the project are disabled. (default: False)
+    # restrict-future-imports RESTRICT_FUTURE_IMPORTS: If set to True,
+    # future imports for the project are disabled. (default: False)
+    # restrict-init-imports RESTRICT_INIT_IMPORTS: If set to True, importing
+    # __init__ files is restricted for the project. (default: True)
+    # restrict-main-imports RESTRICT_MAIN_IMPORTS: If set to True, importing
+    # __main__ files is restricted for the project. (default: True)
+    # restrict-test-imports RESTRICT_TEST_IMPORTS: If set to True, importing
+    # test modules (test_*/ *_test.py) is restricted for the project. (default: True)
+    # restrict-conftest-imports RESTRICT_CONFTEST_IMPORTS: If set to True,
+    # importing from conftest.py files is restricted for the project. (default: True)
+}
+
+
 def register_options(
     option_manager: OptionManager,
     item: list | str,
@@ -212,11 +294,14 @@ def register_options(
         import_type = item.split("_")[1]
         if not help_string:
             help_string = (
-                f"Disables {import_type.title()} Imports for project. "
+                f"This option allows you to disable {import_type.lower()} "
+                f"imports for project. "
                 f"(default: {option_default_value})"
             )
-    else:
-        help_string = f"{setting_key}. (default: {option_default_value})"
+
+    # defaults for is_restriction is False
+    if option_default_value == "":
+        help_string = f"{HELP_STRINGS[setting_key]}"
 
     if not isinstance(option_default_value, bool if is_restriction else str):
         raise TypeError(

--- a/src/flake8_custom_import_rules/flake8_plugin.py
+++ b/src/flake8_custom_import_rules/flake8_plugin.py
@@ -58,22 +58,6 @@ class Plugin(CustomImportRulesChecker):
         """
         # Add options for CustomImportRulesChecker
 
-        register_opt(
-            option_manager,
-            "--base-packages",
-            default="",
-            action="store",
-            type=str,
-            help=(
-                "Import names to consider as first party modules (i.e., the name of "
-                "your package or library). If not set, some functionality will be "
-                "disabled. (default: '')"
-            ),
-            parse_from_config=True,
-            comma_separated_list=True,
-            normalize_paths=False,
-        )
-
         register_options(option_manager, CUSTOM_IMPORT_RULES, is_restriction=False)
 
         register_opt(
@@ -83,7 +67,8 @@ class Plugin(CustomImportRulesChecker):
             action="store",
             type=bool,
             help=(
-                f"Only top level imports are permitted in the project. "
+                f"This option allows you to enforce that only top-level "
+                f"imports are permitted in the project. "
                 f"(default: {DEFAULT_CHECKER_SETTINGS.TOP_LEVEL_ONLY_IMPORTS})"
             ),
             parse_from_config=True,


### PR DESCRIPTION
Help strings added:

## RATIONALE

A short description of the changes in this pull request. If the pull request is
related to an open issue, mention it here.

## CHANGES

HELP_STRINGS = {
    "base-packages": (
        "This option allows you to define the main packages in your project. "
        "These packages are considered first-party and are generally the ones "
        "you are developing in your project. Import names to consider as "
        "first party modules (i.e., the name of your package or library). "
        "For example, if you're building a library named 'my_library', you "
        "would include 'my_library' as a base package. If this option is not "
        "set, some functionality will be disabled."
    ),
    "import-restrictions": (
        "This option allows you to restrict specific import capabilities for "
        "packages. You can define a list of packages that are restricted from "
        "importing certain packages or modules within your base package. "
        "This option allows you to define the main packages in your project."
    ),
    "restricted-packages": (
        "This option lets you specify a list of packages that are not "
        "permitted to be imported or used by other packages or modules within "
        "your base package. This helps maintain a clear separation between "
        "high-level and low-level packages."
    ),
    "std-lib-only": (
        "This option allows you to specify a set of packages that can only "
        "import from third-party libraries. This can be useful to limit the "
        "dependencies of a package to external libraries only."
    ),
    "project-only": (
        "This option allows you to restrict a package to import only from the "
        "local package and the project's top-level package. This will treat "
        "the packages defined in `--base-packages` as the top-level package."
    ),
    "base-package-only": (
        "This option lets you restrict a package to import only from the "
        "project's top-level package. This will treat the first package "
        "defined in base_packages as the top-level package."
    ),
    "first-party-only": (
        "This option enables you to specify a set of packages that can only "
        "import from the local packages (i.e., the packages defined in your "
        "base packages)."
    ),
    "third-party-only": (
        "Define packages that should only import from third-party libraries. "
        "This rule helps maintain a clear dependency scope for the specified "
        "packages."
    ),
    "isolated-modules": (
        "This option allows you to define a list of modules that cannot import "
        "from any other modules within your base package. This ensures that "
        "certain modules remain standalone and do not introduce unwanted "
        "dependencies."
    ),
    # "top-level-only-imports": If set to True, only top-level imports are
    # permitted in the project. (default: True)
    # "restrict-relative-imports": If set to True, relative imports for the
    # project are disabled. (default: True)
    # restrict-local-imports RESTRICT_LOCAL_IMPORTS: If set to True, local
    # imports for the project are disabled. (default: True)
    # restrict-conditional-imports RESTRICT_CONDITIONAL_IMPORTS: If set to
    # True, conditional imports for the project are disabled. (default: False)
    # restrict-dynamic-imports RESTRICT_DYNAMIC_IMPORTS: If set to True,
    # dynamic imports for the project are disabled. (default: True)
    # restrict-private-imports RESTRICT_PRIVATE_IMPORTS: If set to True,
    # private imports for the project are disabled. (default: True)
    # restrict-wildcard-imports RESTRICT_WILDCARD_IMPORTS: If set to True,
    # wildcard imports for the project are disabled. (default: True)
    # restrict-aliased-imports RESTRICT_ALIASED_IMPORTS: If set to True,
    # aliased imports for the project are disabled. (default: False)
    # restrict-future-imports RESTRICT_FUTURE_IMPORTS: If set to True,
    # future imports for the project are disabled. (default: False)
    # restrict-init-imports RESTRICT_INIT_IMPORTS: If set to True, importing
    # __init__ files is restricted for the project. (default: True)
    # restrict-main-imports RESTRICT_MAIN_IMPORTS: If set to True, importing
    # __main__ files is restricted for the project. (default: True)
    # restrict-test-imports RESTRICT_TEST_IMPORTS: If set to True, importing
    # test modules (test_*/ *_test.py) is restricted for the project. (default: True)
    # restrict-conftest-imports RESTRICT_CONFTEST_IMPORTS: If set to True,
    # importing from conftest.py files is restricted for the project. (default: True)
}

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
