### PR TITLE
refactor(error-codes): make error code checks using set instead of list

### DIFF
--- a/src/flake8_custom_import_rules/core/error_messages.py
+++ b/src/flake8_custom_import_rules/core/error_messages.py
@@ -1,5 +1,5 @@
 """ Error messages for custom import rules. """
-from attr import define
+from attrs import define
 
 from flake8_custom_import_rules.codes.error_codes import ErrorCode
 from flake8_custom_import_rules.core.nodes import ParsedNode

--- a/src/flake8_custom_import_rules/core/import_rules.py
+++ b/src/flake8_custom_import_rules/core/import_rules.py
@@ -89,10 +89,11 @@ class CustomImportRules:
     file_root_package_name: str = field(default=None)
     file_packages: list = field(default=None)
 
-    codes_to_check: list[ErrorCode] = ErrorCode.get_all_error_codes()
+    codes_to_check: set[ErrorCode] = set(ErrorCode.get_all_error_codes())
     # Can only check CIR codes if the file is not stdin
     check_custom_import_rules: bool = field(default=filename_not_in_stdin_identifiers(filename))
 
+    top_level_only_imports: bool = field(default=False)  # Not Implemented
     import_restrictions: dict = field(factory=dict)
     restricted_packages: list[str] = field(factory=list)
     file_in_restricted_packages: bool = field(default=False)
@@ -106,10 +107,9 @@ class CustomImportRules:
     third_party_only: bool = field(default=False, init=False)
 
     def __attrs_post_init__(self) -> None:
-        """Post init."""
+        """Post init CustomImportRules."""
         logging.debug(f"file_identifier: {self.file_identifier}")
         self.nodes = sorted(self.nodes, key=lambda element: element.lineno)
-        # print(f"nodes: {self.nodes}")
 
         # for these restrictions we want to match a file identifier
         # because the import rules correspond to an ImportType
@@ -122,12 +122,13 @@ class CustomImportRules:
         self.third_party_only = get_file_matches_custom_rule("THIRD_PARTY_ONLY")(self)
         self.file_in_restricted_packages = get_file_matches_custom_rule("RESTRICTED_PACKAGES")(self)
 
+        self.top_level_only_imports = self.checker_settings.TOP_LEVEL_ONLY_IMPORTS
         self.import_restrictions = self.checker_settings.IMPORT_RESTRICTIONS
         self.restricted_packages = self.checker_settings.RESTRICTED_PACKAGES
-        # print(f"Restricted packages: {self.restricted_packages}")
 
         logger.info(f"File packages: {self.file_packages}")
         logger.info(f"Restricted packages: {self.restricted_packages}")
+        # print(f"Restricted packages: {self.restricted_packages}")
         logger.info(f"Restricted identifiers: {self.restricted_identifiers}")
         logger.debug(f"Restricted identifiers keys: {list(self.restricted_identifiers.keys())}")
 

--- a/src/flake8_custom_import_rules/core/nodes.py
+++ b/src/flake8_custom_import_rules/core/nodes.py
@@ -1,8 +1,8 @@
 """Parsed Nodes for custom import rules."""
 from enum import Enum
 
-from attr import define
-from attr import field
+from attrs import define
+from attrs import field
 
 
 class ImportType(Enum):

--- a/src/flake8_custom_import_rules/core/restricted_import_visitor.py
+++ b/src/flake8_custom_import_rules/core/restricted_import_visitor.py
@@ -4,8 +4,8 @@ import logging
 import os
 from collections import defaultdict
 
-from attr import define
-from attr import field
+from attrs import define
+from attrs import field
 
 from flake8_custom_import_rules.utils.file_utils import get_file_path_from_module_name
 from flake8_custom_import_rules.utils.file_utils import get_relative_path_from_absolute_path
@@ -19,7 +19,21 @@ def get_restricted_package_strings(
     restricted_packages: list[str],
     file_packages: list[str],
 ) -> list[str]:
-    """Get restricted package strings."""
+    """
+    Get restricted package strings.
+
+    Parameters
+    ----------
+    restricted_packages: list[str]
+        The restricted packages.
+    file_packages: list[str]
+        The file packages to check. (The module and parent packages.)
+
+    Returns
+    -------
+    list[str]
+        The restricted package strings.
+    """
     return [
         restricted_import
         for restricted_import in restricted_packages
@@ -31,7 +45,21 @@ def get_import_restriction_strings(
     import_restrictions: defaultdict[str, list[str]],
     file_packages: list[str],
 ) -> list[str]:
-    """Get import restriction strings."""
+    """
+    Get import restriction strings.
+
+    Parameters
+    ----------
+    import_restrictions: defaultdict[str, list[str]]
+        The import restrictions.
+    file_packages: list[str]
+        The file packages to check. (The module and parent packages.)
+
+    Returns
+    -------
+    list[str]
+        The import restriction strings.
+    """
     import_restriction_keys = list(import_restrictions.keys())
     parsed_import_restriction_keys: list = [
         import_restriction_key
@@ -51,7 +79,19 @@ def get_import_restriction_strings(
 def get_import_strings(
     restrictions: list[str],
 ) -> list[str]:
-    """Get import strings."""
+    """
+    Get import strings.
+
+    Parameters
+    ----------
+    restrictions: list[str]
+        The restrictions to get the import strings for.
+
+    Returns
+    -------
+    list[str]
+        The import strings.
+    """
     return [f"import {restriction}\n" for restriction in sorted(restrictions)]
 
 
@@ -62,12 +102,17 @@ def subdict_from_keys(
     """
     Function to create a subset of a dictionary given a list of keys.
 
-    Args:
-    d (dict): The original dictionary.
-    keys (list): The keys for the sub-dictionary.
+    Parameters
+    ----------
+    import_restrictions: defaultdict[str, list[str]]
+        The original dictionary.
+    keys: list[str]
+        The keys for the sub-dictionary.
 
-    Returns:
-    dict: A sub-dictionary with the given keys.
+    Returns
+    -------
+    dict
+        A sub-dictionary with the given keys.
     """
     return {k: import_restrictions[k] for k in keys if k in import_restrictions}
 
@@ -78,12 +123,17 @@ def find_keys_with_string(
     """
     Function to find keys with the target string in their lists.
 
-    Args:
-    dd (collections.defaultdict): The defaultdict(list) to search.
-    target_string (str): The string to search for.
+    Parameters
+    ----------
+    import_restrictions : defaultdict
+        The defaultdict(list) to search.
+    target_string : str
+        The string to search for.
 
-    Returns:
-    list: A list of keys where the string is found in their lists.
+    Returns
+    -------
+    list
+        A list of keys where the string is found in their lists.
     """
     return [k for k, v in import_restrictions.items() if target_string in v]
 
@@ -94,7 +144,7 @@ class RestrictedImportVisitor(ast.NodeVisitor):
 
     _restricted_packages: list[str]
     _import_restrictions: defaultdict[str, list[str]]
-    _check_module_exists: bool = field(default=True)
+    _check_module_exists: bool = field(default=True)  # Not Implemented
     _file_packages: list[str] = field(default=list)
     _restrictions: list[str] = field(init=False)
     _lines: list[str] = field(init=False)
@@ -104,7 +154,7 @@ class RestrictedImportVisitor(ast.NodeVisitor):
     restricted_identifiers: defaultdict[str, dict] = field(init=False)
 
     def __attrs_post_init__(self) -> None:
-        """Initialize."""
+        """Initialize RestrictedImportVisitor."""
         self._restrictions = self._get_restricted_package_strings()
         self._restrictions.extend(self._get_import_restriction_strings())
         self._restrictions = sorted(list(set(self._restrictions)))
@@ -112,6 +162,10 @@ class RestrictedImportVisitor(ast.NodeVisitor):
         self._lines = get_import_strings(self._restrictions)
         self._tree = ast.parse("".join(self._lines))
         self.restricted_identifiers = defaultdict(lambda: defaultdict(str))
+
+        # Not Implemented
+        # TODO: Implement checking if modules exist
+        self._check_module_exists = False
 
     def _get_restricted_package_strings(self) -> list[str]:
         """Get restricted package strings."""
@@ -175,7 +229,7 @@ class RestrictedImportVisitor(ast.NodeVisitor):
 def get_restricted_identifiers(
     restricted_packages: list[str] | str,
     import_restrictions: defaultdict[str, list[str]] | None = None,
-    check_module_exists: bool = True,
+    check_module_exists: bool = True,  # Not Implemented
     file_packages: list | None = None,
 ) -> defaultdict[str, dict]:
     """
@@ -207,7 +261,7 @@ def get_restricted_identifiers(
     visitor = RestrictedImportVisitor(
         restricted_packages=restricted_packages,
         import_restrictions=import_restrictions,
-        check_module_exists=check_module_exists,
+        check_module_exists=check_module_exists,  # Not Implemented
         file_packages=file_packages,
     )
     return visitor.get_restricted_identifiers()

--- a/src/flake8_custom_import_rules/core/rules_checker.py
+++ b/src/flake8_custom_import_rules/core/rules_checker.py
@@ -118,13 +118,11 @@ class CustomImportRulesChecker:
     def restricted_identifiers(self) -> defaultdict[str, dict[Any, Any]] | None:
         """Return the restricted identifiers."""
         logger.debug(f"file_packages: {self.visitor.file_packages}")
-        # restricted_packages = self.options.get("restricted_packages", [])
-        # logger.debug(f"restricted_packages: {restricted_packages}")
         if self._restricted_identifiers is None:
             self._restricted_identifiers = get_restricted_identifiers(
                 restricted_packages=self.options.get("restricted_packages", []),
                 import_restrictions=self.options.get("import_restrictions", defaultdict(list)),
-                check_module_exists=True,
+                check_module_exists=False,  # Not Implemented
                 file_packages=self.visitor.file_packages,
             )
         logger.debug(f"Restricted Identifiers: {self._restricted_identifiers}")
@@ -137,7 +135,14 @@ class CustomImportRulesChecker:
         return self._options
 
     def update_checker_settings(self, updated_options: dict) -> None:
-        """Update the checker settings."""
+        """
+        Update the checker settings. Helper method for testing.
+
+        Parameters
+        ----------
+        updated_options : dict
+            The updated options to use.
+        """
         test_env = self.options.get("test_env", True)
         if not test_env:
             raise ValueError("Cannot update options in a non-test environment.")
@@ -149,6 +154,7 @@ class CustomImportRulesChecker:
     def import_rules(self) -> CustomImportRules:
         """Return the import rules."""
         visitor = self.visitor
+
         self._import_rules = CustomImportRules(
             nodes=self.nodes,
             dynamic_nodes=visitor.dynamic_nodes,


### PR DESCRIPTION
## RATIONALE

This will be faster.

## CHANGES

- Update docstrings
- `ErrorCode.get_all_error_codes()` -> `set(ErrorCode.get_all_error_codes())`


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
