### PR TITLE
fix(file-utils): add try except section to find prefix function

### DIFF
--- a/example_repos/my_base_module/my_base_module/package_a/module_a_relative.py
+++ b/example_repos/my_base_module/my_base_module/package_a/module_a_relative.py
@@ -33,7 +33,7 @@ class ARelative:
         return self._created_at
 
 
-def initialize_class_a_relative(self) -> ARelative:
+def initialize_a_relative(self) -> ARelative:
     """Get the class A."""
     return ARelative(
         name=f"{self._name}: ARelative", description=f"{self._description}: ARelative"

--- a/poetry.lock
+++ b/poetry.lock
@@ -760,7 +760,6 @@ files = [
     {file = "lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e"},
     {file = "lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991"},
     {file = "lxml-4.9.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd"},
-    {file = "lxml-4.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c"},
     {file = "lxml-4.9.3-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8"},
     {file = "lxml-4.9.3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76"},
     {file = "lxml-4.9.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23"},
@@ -769,7 +768,6 @@ files = [
     {file = "lxml-4.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d"},
     {file = "lxml-4.9.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5"},
     {file = "lxml-4.9.3-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf"},
-    {file = "lxml-4.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a"},
     {file = "lxml-4.9.3-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f"},
     {file = "lxml-4.9.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b"},
     {file = "lxml-4.9.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120"},
@@ -789,7 +787,6 @@ files = [
     {file = "lxml-4.9.3-cp36-cp36m-macosx_11_0_x86_64.whl", hash = "sha256:64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12"},
     {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5"},
     {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98"},
-    {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190"},
     {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_28_x86_64.whl", hash = "sha256:4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2"},
     {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c"},
     {file = "lxml-4.9.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584"},
@@ -799,7 +796,6 @@ files = [
     {file = "lxml-4.9.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf"},
     {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601"},
     {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129"},
-    {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4"},
     {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d"},
     {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693"},
     {file = "lxml-4.9.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4"},
@@ -809,7 +805,6 @@ files = [
     {file = "lxml-4.9.3-cp37-cp37m-win_amd64.whl", hash = "sha256:120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52"},
     {file = "lxml-4.9.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc"},
     {file = "lxml-4.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac"},
-    {file = "lxml-4.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db"},
     {file = "lxml-4.9.3-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce"},
     {file = "lxml-4.9.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42"},
     {file = "lxml-4.9.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa"},
@@ -819,7 +814,6 @@ files = [
     {file = "lxml-4.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96"},
     {file = "lxml-4.9.3-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340"},
     {file = "lxml-4.9.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7"},
-    {file = "lxml-4.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b"},
     {file = "lxml-4.9.3-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da"},
     {file = "lxml-4.9.3-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e"},
     {file = "lxml-4.9.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d"},
@@ -830,16 +824,13 @@ files = [
     {file = "lxml-4.9.3-cp39-cp39-win_amd64.whl", hash = "sha256:4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2"},
     {file = "lxml-4.9.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35"},
     {file = "lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0"},
-    {file = "lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3"},
     {file = "lxml-4.9.3-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b"},
     {file = "lxml-4.9.3-pp38-pypy38_pp73-macosx_11_0_x86_64.whl", hash = "sha256:5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b"},
     {file = "lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7"},
-    {file = "lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d"},
     {file = "lxml-4.9.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b"},
     {file = "lxml-4.9.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a"},
     {file = "lxml-4.9.3-pp39-pypy39_pp73-macosx_11_0_x86_64.whl", hash = "sha256:ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0"},
     {file = "lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694"},
-    {file = "lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7"},
     {file = "lxml-4.9.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"},
     {file = "lxml-4.9.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9"},
     {file = "lxml-4.9.3.tar.gz", hash = "sha256:48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c"},
@@ -1071,17 +1062,17 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.2.1"
+version = "1.3.0"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings_python-1.2.1-py3-none-any.whl", hash = "sha256:7c08f33e9ba7b1655e9cf0608eba3ce7a9513bd8b42a68a8d24ffaf4a6a50cfc"},
-    {file = "mkdocstrings_python-1.2.1.tar.gz", hash = "sha256:ae40825b3b676a94626882901ed9c8fcf9a7f0330e466ffe37ce15c525987aa9"},
+    {file = "mkdocstrings_python-1.3.0-py3-none-any.whl", hash = "sha256:36c224c86ab77e90e0edfc9fea3307f7d0d245dd7c28f48bbb2203cf6e125530"},
+    {file = "mkdocstrings_python-1.3.0.tar.gz", hash = "sha256:f967f84bab530fcc13cc9c02eccf0c18bdb2c3bab5c55fa2045938681eec4fc4"},
 ]
 
 [package.dependencies]
-griffe = ">=0.30"
+griffe = ">=0.30,<0.33"
 mkdocstrings = ">=0.20"
 
 [[package]]
@@ -1345,13 +1336,13 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.15.1"
+version = "2.16.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
-    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
+    {file = "Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
+    {file = "Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
 ]
 
 [package.extras]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -61,7 +61,6 @@ else:
             "src/flake8_custom_import_rules/core/rules_checker.py",
         ]
 
-
         # gcc arguments hack: enable optimizations
         os.environ["CFLAGS"] = "-O3"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,9 @@ ignore=
     W503,
     # line break after binary operator
     W504
-exclude = .tox,*.egg,tests/,.venv,.mypy_cache,.pytest*,.git,.hg,.svn,CVS,build,dist
+exclude = .tox,*.egg*,tests/,.venv,.mypy_cache,.pytest*,.git,.hg,.svn,CVS,build,dist,*.pyc,.bak,*.xml,*.yml,*.rst,*.md
+filename = *.py
 select = E,W,F,N,CIR,PIR
+
+# flake8-custom-import-rules
+base-packages = flake8_custom_import_rules, my_base_module

--- a/src/flake8_custom_import_rules/core/node_visitor.py
+++ b/src/flake8_custom_import_rules/core/node_visitor.py
@@ -101,6 +101,7 @@ class CustomImportRulesVisitor(ast.NodeVisitor):
             self.stdlib_names = sys.stdlib_module_names
 
         self.resolve_local_imports = self.filename not in STDIN_IDENTIFIERS
+
         logger.debug(f"Resolve local imports: {self.resolve_local_imports}")
         self.file_path = (
             Path(self.filename).resolve()
@@ -108,7 +109,6 @@ class CustomImportRulesVisitor(ast.NodeVisitor):
             else None
         )
         logger.info(f"Visitor filename: {self.filename}")
-        # print("Visitor filename: ", self.filename)
         self.file_identifier = (
             get_module_name_from_filename(str(self.filename))
             if self.resolve_local_imports

--- a/src/flake8_custom_import_rules/flake8_plugin.py
+++ b/src/flake8_custom_import_rules/flake8_plugin.py
@@ -57,7 +57,6 @@ class Plugin(CustomImportRulesChecker):
         https://github.com/PyCQA/flake8/blob/main/src/flake8/options/manager.py
         """
         # Add options for CustomImportRulesChecker
-
         register_options(option_manager, CUSTOM_IMPORT_RULES, is_restriction=False)
 
         # Not Implemented Yet
@@ -67,7 +66,7 @@ class Plugin(CustomImportRulesChecker):
             default=DEFAULT_CHECKER_SETTINGS.TOP_LEVEL_ONLY_IMPORTS,
             action="store",
             type=bool,
-            help="Not Implemented Yet",
+            help="Not Implemented",
             # help=(
             #     f"This option allows you to enforce that only top-level "
             #     f"imports are permitted in the project. If violated, could "
@@ -88,12 +87,21 @@ class Plugin(CustomImportRulesChecker):
     def parse_options(
         cls, option_manager: OptionManager, parse_options: Namespace, *args: Any
     ) -> None:
-        """Parse options for flake8-custom-import-rules."""
+        """
+        Parse options for flake8-custom-import-rules.
+
+        Parameters
+        ----------
+        option_manager : OptionManager
+            The option manager from flake8.options.manager
+        parse_options : Namespace
+            The options to parse.
+        args : Any
+            Additional arguments.
+        """
         logger.debug(f"Option Manager: {option_manager}")
         logger.debug(f"Options: {parse_options}")
         logger.debug(f"Args: {args}")
-        # print(f"\n\nOptions: {parse_options}")
-        # print(f"\n\nArgs: {args}")
 
         # Parse options for CustomImportRulesChecker
         options: dict = {}
@@ -115,7 +123,18 @@ class Plugin(CustomImportRulesChecker):
         cls._options = parsed_options
 
     def error(self, error: ErrorMessage) -> tuple:
-        """Return the error."""
+        """
+        Return the error message in a form that can be used by flake8.
+
+        Parameters
+        ----------
+        error : ErrorMessage
+            The error message.
+
+        Returns
+        -------
+        tuple[int, int, str, type[Any]]
+        """
         return (
             error.lineno,
             error.col_offset,
@@ -126,6 +145,5 @@ class Plugin(CustomImportRulesChecker):
     def run(self) -> Generator[tuple[int, int, str, type[Any]], None, None]:
         """Run flake8-custom-import-rules."""
         # Run CustomImportRulesChecker
-        # print(f"Run Options: {self.options}")
         logger.debug(f"Run Options: {self.options}")
         yield from self.check_custom_import_rules()

--- a/src/flake8_custom_import_rules/utils/node_utils.py
+++ b/src/flake8_custom_import_rules/utils/node_utils.py
@@ -13,6 +13,7 @@ def get_package_names(module_name: str) -> list[str] | None:
     Parameters
     ----------
     module_name : str
+        The module name.
 
     Returns
     -------

--- a/src/flake8_custom_import_rules/utils/parse_utils.py
+++ b/src/flake8_custom_import_rules/utils/parse_utils.py
@@ -20,9 +20,18 @@ COMMA_SEPARATED_LIST_RE = re.compile(r"[,\s]")
 
 
 def parse_comma_separated_list(value: list | str) -> set[str]:
-    """Parse a comma-separated list of values."""
-    # items = re.split(r"\s*,\s*", value)
-    # return {item.strip() for item in items if item}
+    """
+    Parse a comma-separated list of values.
+
+    Parameters
+    ----------
+    value : list | str
+        The value to parse.
+
+    Returns
+    -------
+    set[str]
+    """
     if isinstance(value, list):
         return {item.strip() for item in value if item}
     value = COMMA_SEPARATED_LIST_RE.split(value)
@@ -129,7 +138,20 @@ def check_string(
 
 
 def does_file_match_custom_rule(file_identifier: str, custom_rules: list[str] | str | None) -> bool:
-    """Check if a file identifier is in a custom rule."""
+    """
+    Check if a file identifier is in a custom rule.
+
+    Parameters
+    ----------
+    file_identifier : str
+        The file identifier to check.
+    custom_rules : list[str] | str | None
+        A list of custom rules or a single custom rule to check against.
+
+    Returns
+    -------
+    bool
+    """
     if custom_rules is None:
         return False
     custom_rules = [custom_rules] if isinstance(custom_rules, str) else custom_rules
@@ -139,7 +161,20 @@ def does_file_match_custom_rule(file_identifier: str, custom_rules: list[str] | 
 def does_import_match_restricted_imports(
     node_identifier: str, restricted_imports: list[str] | str | None
 ) -> bool:
-    """Check if an import identifier is in a restricted import."""
+    """
+    Check if an import identifier is in a restricted import.
+
+    Parameters
+    ----------
+    node_identifier : str
+        The import identifier to check.
+    restricted_imports : list[str] | str | None
+        A list of restricted imports or a single restricted import to check against.
+
+    Returns
+    -------
+    bool
+    """
     if restricted_imports is None:
         return False
     restricted_imports = (


### PR DESCRIPTION
def find_prefix(filename: str) -> str:
    """
    Find the appropriate module prefix string for the filename.

    Parameters
    ----------
    filename : str
        The filename to find the prefix for.

    Returns
    -------
    str
    """
    filename = os.path.abspath(filename)
    logger.debug(f"filename in find_prefix: {filename}")

    # Find the deepest path
    matches = (path for path in sys.path if filename.startswith(path))
    try:
        return max(matches, key=len)

    except ValueError as e:
        machine = sys.platform
        if machine in {"win32", "cygwin"}:
            export_string = f"set PYTHONPATH=%PYTHONPATH%;{os.getcwd()}"
        else:
            export_string = f"export PYTHONPATH=$PYTHONPATH:{os.getcwd()}"

        raise ValueError(
            f"Could not find prefix for {filename}. "
            f"To fix this, add the directory containing {filename} "
            f"to sys.path using `{export_string}`."
        ) from e

## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
