### PR TITLE
feat(option-utils): add check conflict function and add tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,24 +261,25 @@ Custom Import Rules (CIR)
 Custom Import Rules allowed import types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-------------------+---------+--------------+-------------+-------------+--------+
-| RULE              | STD LIB | PROJECT [#]_ | FIRST PARTY | THIRD PARTY | FUTURE |
-+===================+=========+==============+=============+=============+========+
-| std_lib_only      | X       |              |             |             | X      |
-+-------------------+---------+--------------+-------------+-------------+--------+
-| project_only      | X       | X            | X           |             | X      |
-+-------------------+---------+--------------+-------------+-------------+--------+
-| base_package_only | X       | X            |             |             | X      |
-+-------------------+---------+--------------+-------------+-------------+--------+
-| first_party_only  | X       |              | X           |             | X      |
-+-------------------+---------+--------------+-------------+-------------+--------+
-| third_party_only  | X       |              |             | X           | X      |
-+-------------------+---------+--------------+-------------+-------------+--------+
-| isolated          | X       |              |             | X           | X      |
-+-------------------+---------+--------------+-------------+-------------+--------+
++-------------------+---------+--------------+-------------+-------------+-------------+
+| RULE              | STD LIB | PROJECT [#]_ | FIRST PARTY | THIRD PARTY | FUTURE [#]_ |
++===================+=========+==============+=============+=============+=============+
+| std_lib_only      | X       |              |             |             | X           |
++-------------------+---------+--------------+-------------+-------------+-------------+
+| project_only      | X       | X            | X           |             | X           |
++-------------------+---------+--------------+-------------+-------------+-------------+
+| base_package_only | X       | X            |             |             | X           |
++-------------------+---------+--------------+-------------+-------------+-------------+
+| first_party_only  | X       |              | X           |             | X           |
++-------------------+---------+--------------+-------------+-------------+-------------+
+| third_party_only  | X       |              |             | X           | X           |
++-------------------+---------+--------------+-------------+-------------+-------------+
+| isolated          | X       |              |             | X           | X           |
++-------------------+---------+--------------+-------------+-------------+-------------+
 
 
 .. [#] Technically project imports are "First Party" imports, but in this case we want to make a distinction between the top-level package and the rest of the project.
+.. [#] To restrict future imports, use the `--restrict-future-imports` flag.
 
 Example Configurations
 ----------------------
@@ -544,3 +545,5 @@ Acknowledgements
     ``flake8`` documentation on writing plugins.
 -   `A flake8 plugin from scratch <https://www.youtube.com/watch?v=ot5Z4KQPBL8>`_ - YouTube video on
     writing a custom ``flake8`` plugin.
+-   `flake8-bugbear <https://github.com/PyCQA/flake8-bugbear>`_ - ``flake8``
+    plugin that finds likely bugs and design problems in your program.

--- a/example_repos/my_base_module/my_second_base_package/module_three.py
+++ b/example_repos/my_base_module/my_second_base_package/module_three.py
@@ -37,7 +37,6 @@ class ModuleThree:
         """Get the created_at."""
         return self._created_at
 
-
     def initialize_class_x(self) -> X:
         """Initialize class x."""
         return X(

--- a/poetry.lock
+++ b/poetry.lock
@@ -756,8 +756,6 @@ files = [
     {file = "lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl", hash = "sha256:b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c"},
     {file = "lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d"},
     {file = "lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef"},
-    {file = "lxml-4.9.3-cp27-cp27m-win32.whl", hash = "sha256:2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7"},
-    {file = "lxml-4.9.3-cp27-cp27m-win_amd64.whl", hash = "sha256:4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1"},
     {file = "lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb"},
     {file = "lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e"},
     {file = "lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991"},

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -3,8 +3,8 @@
 This script is called by poetry when building the package. It will compile
 Cython files if Cython is installed. Otherwise, it will do nothing.
 
-See https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules
-for more information.
+See #distributing-cython-modules for more information.
+https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html
 
 Taken from:
 https://stackoverflow.com/questions/63679315/how-to-use-cython-with-poetry

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,11 @@ ignore=
     W503,
     # line break after binary operator
     W504
-exclude = .tox,*.egg*,tests/,.venv,.mypy_cache,.pytest*,.git,.hg,.svn,CVS,build,dist,*.pyc,.bak,*.xml,*.yml,*.rst,*.md
+exclude=
+    .tox,*.egg*,
+    .venv,.mypy_cache,.pytest*,.git,.hg,.svn,
+    *.pyc,.bak,*.xml,*.yml,*.rst,*.md,
+    CVS,build,dist,tests/,
 filename = *.py
 select = E,W,F,N,CIR,PIR
 

--- a/src/flake8_custom_import_rules/core/error_messages.py
+++ b/src/flake8_custom_import_rules/core/error_messages.py
@@ -7,7 +7,21 @@ from flake8_custom_import_rules.core.nodes import ParsedNode
 
 @define(slots=True)
 class ErrorMessage:
-    """Error message"""
+    """Error message
+
+    Attributes
+    ----------
+    lineno : int
+        The line number of the error.
+    col_offset : int
+        The column offset of the error.
+    code : str
+        The error code.
+    message : str
+        The error message to show to the user.
+    custom_explanation : str | None
+        Custom explanation to add to the error message.
+    """
 
     lineno: int
     col_offset: int
@@ -26,7 +40,22 @@ def standard_error_message(
     error_code: ErrorCode,
     custom_explanation: str | None = None,
 ) -> ErrorMessage:
-    """Generate error message from node."""
+    """
+    Generate error message from node.
+
+    Parameters
+    ----------
+    node : ParsedNode
+        The node that caused the error.
+    error_code : ErrorCode
+        The error code.
+    custom_explanation : str | None
+        Custom explanation to add to the error message.
+
+    Returns
+    -------
+    ErrorMessage
+    """
     return ErrorMessage(
         lineno=node.lineno,
         col_offset=node.col_offset,
@@ -53,7 +82,20 @@ def std_lib_only_error(
     node: ParsedNode,
     error_code: ErrorCode,
 ) -> ErrorMessage:
-    """Generate error message for std lib only."""
+    """
+    Generate error message for std lib only.
+
+    Parameters
+    ----------
+    node : ParsedNode
+        The node that caused the error.
+    error_code : ErrorCode
+        The error code.
+
+    Returns
+    -------
+    ErrorMessage
+    """
     custom_explanation = (
         f"Using '{node.import_statement}'."
         # f"which is not a Python standard library."
@@ -65,7 +107,20 @@ def third_party_only_error(
     node: ParsedNode,
     error_code: ErrorCode,
 ) -> ErrorMessage:
-    """Generate error message for third-party only."""
+    """
+    Generate error message for third-party only.
+
+    Parameters
+    ----------
+    node : ParsedNode
+        The node that caused the error.
+    error_code : ErrorCode
+        The error code.
+
+    Returns
+    -------
+    ErrorMessage
+    """
     custom_explanation = (
         f"Using '{node.import_statement}'."
         # f"which is not a third-party library."
@@ -77,7 +132,19 @@ def first_party_only_error(
     node: ParsedNode,
     error_code: ErrorCode,
 ) -> ErrorMessage:
-    """Generate error message for third-party only."""
+    """Generate error message for first-party only.
+
+    Parameters
+    ----------
+    node : ParsedNode
+        The node that caused the error.
+    error_code : ErrorCode
+        The error code.
+
+    Returns
+    -------
+    ErrorMessage
+    """
     custom_explanation = (
         f"Using '{node.import_statement}'."
         # f"which is not a first-party library."
@@ -89,7 +156,19 @@ def restricted_imports_error(
     node: ParsedNode,
     error_code: ErrorCode,
 ) -> ErrorMessage:
-    """Generate error message for restricted imports."""
+    """Generate error message for restricted imports.
+
+    Parameters
+    ----------
+    node : ParsedNode
+        The node that caused the error.
+    error_code : ErrorCode
+        The error code.
+
+    Returns
+    -------
+    ErrorMessage
+    """
     custom_explanation = (
         f"Using '{node.import_statement}'. Restricted package/module "
         f"cannot be imported outside package/module."

--- a/src/flake8_custom_import_rules/core/import_rules.py
+++ b/src/flake8_custom_import_rules/core/import_rules.py
@@ -42,12 +42,13 @@ def filename_not_in_stdin_identifiers(
 
 
 def get_file_matches_custom_rule(option_key: str) -> Callable[[CustomImportRules], bool]:
-    """Get rule."""
+    """Get custom rule."""
     option_key = option_key.upper()
 
     def match_custom_rule(instance: CustomImportRules) -> bool:
         """Match custom rule."""
         custom_rule = getattr(instance.checker_settings, option_key, None)
+
         if custom_rule is None:
             logger.error(f"Option key '{option_key}' not found in checker settings")
             return False
@@ -64,6 +65,7 @@ def get_isolated_package_rule(option_key: str) -> Callable[[CustomImportRules], 
     def isolated_package(instance: CustomImportRules) -> bool:
         """Match custom rule."""
         custom_rule = getattr(instance.checker_settings, option_key, None)
+
         if custom_rule is None:
             logger.error(f"Option key '{option_key}' not found in checker settings")
             return False
@@ -75,7 +77,94 @@ def get_isolated_package_rule(option_key: str) -> Callable[[CustomImportRules], 
 
 @define(slots=True)
 class CustomImportRules:
-    """Custom Import Rules for flake8 & Python Projects"""
+    """Custom Import Rules for flake8 & Python Projects
+
+    Attributes
+    ----------
+    nodes : list[ParsedNode]
+        List of parsed nodes from the AST. Contains all the import nodes
+        found.
+
+    dynamic_nodes : defaultdict[str, list]
+        Dictionary mapping module names to lists of dynamic import nodes
+        importing that module. Captures dynamic imports like
+        importlib.import_module()
+
+    identifiers : defaultdict[str, dict]
+        Dictionary mapping identifiers (variable names) to information
+        about them like what line they are defined on.
+
+    identifiers_by_lineno : defaultdict[str, list]
+        Dictionary mapping line numbers to lists of identifiers defined
+        on that line. Used for checking if an import is happening after
+        an identifier is defined.
+
+    checker_settings : Settings
+        The configuration settings for the checker like base packages and
+        import restrictions.
+
+    restricted_identifiers : dict
+        Dictionary mapping restricted identifiers (like __import__) to
+        their line number. Used to detect if they are used.
+
+    filename : str
+        The filename of the file being checked.
+
+    file_identifier : str
+        The identifier for the file being checked, which is the filename
+        without the extension.
+
+    file_root_package_name : str
+        The root package name of the file being checked.
+        Used to check if imports are within the root package.
+
+    file_packages : list
+        The package names of the file being checked.
+        Used to check if imports are within allowed packages.
+
+    codes_to_check : set[ErrorCode]
+        The error codes to check for in this file, based on the command
+        line options.
+
+    check_custom_import_rules : bool
+        Whether to check custom import rules at all for this file, based
+        on command line options.
+
+    top_level_only_imports : bool
+        Whether to only allow top-level imports in this file, based on
+        command line options.
+
+    import_restrictions : dict
+        The import restriction flags from the configuration settings.
+
+    restricted_packages : list[str]
+        List of packages restricted from importing, based on
+        configuration settings.
+
+    file_in_restricted_packages : bool
+        Whether the file is in one of the restricted packages.
+
+    project_only : bool
+        Whether to restrict imports to only allow project imports.
+
+    base_package_only : bool
+        Whether to restrict imports to only allow base package imports.
+
+    first_party_only : bool
+        Whether to restrict imports to only allow first-party imports.
+
+    third_party_only : bool
+        Whether to restrict imports to only allow third-party imports.
+
+    std_lib_only : bool
+        Whether to restrict imports to only allow standard library imports.
+
+    isolated_module : bool
+        Whether this module is isolated (can only import standard library).
+
+    isolated_package : bool
+        Whether this package is isolated.
+    """
 
     nodes: list[ParsedNode] = field(factory=list)
     dynamic_nodes: defaultdict[str, list] = defaultdict(list)

--- a/src/flake8_custom_import_rules/defaults.py
+++ b/src/flake8_custom_import_rules/defaults.py
@@ -317,7 +317,7 @@ def register_options(
     if setting_key == "base-packages":
         error_codes = ""
     else:
-        error_codes = f"If violated, could lead to error codes {ERROR_CODES[setting_key]}."
+        error_codes = f"If violated, leads to error codes {ERROR_CODES[setting_key]}."
 
     if is_restriction:
         option_default_value = DEFAULT_CHECKER_SETTINGS.get_settings_value(item.upper())

--- a/src/flake8_custom_import_rules/utils/option_utils.py
+++ b/src/flake8_custom_import_rules/utils/option_utils.py
@@ -1,0 +1,63 @@
+""" Utility functions for the flake8-custom-import-rules plugin options. """
+
+
+def check_conflicts(settings_dict: dict) -> list | None:
+    """
+    Check for conflicts in the provided settings.
+
+    Parameters
+    ----------
+    settings_dict : dict
+        An instance of the Settings class with the configurations.
+
+    Returns
+    -------
+    list | None
+        A list of messages indicating any conflicts or stating that
+        there are no conflicts.
+    """
+
+    conflicts = []
+
+    # Extract lists from settings
+    restricted_packages = settings_dict.get("RESTRICTED_PACKAGES", [])
+    isolated_modules = settings_dict.get("ISOLATED_MODULES", [])
+    std_lib_only = settings_dict.get("STD_LIB_ONLY", [])
+    third_party_only = settings_dict.get("THIRD_PARTY_ONLY", [])
+    first_party_only = settings_dict.get("FIRST_PARTY_ONLY", [])
+    project_only = settings_dict.get("PROJECT_ONLY", [])
+    base_package_only = settings_dict.get("BASE_PACKAGE_ONLY", [])
+
+    # Extract dict from settings
+    import_restrictions = settings_dict.get("IMPORT_RESTRICTIONS", {})
+
+    # Check for intersections among list options
+    if conflict := set(third_party_only).intersection(first_party_only):
+        conflicts.append(
+            f"Conflict: {conflict}. A package cannot be set to both "
+            f"--third-party-only and --first-party-only."
+        )
+    if conflict := set(std_lib_only).intersection(third_party_only):
+        conflicts.append(
+            f"Conflict: {conflict}. A package cannot be set to both "
+            f"--std-lib-only and --third-party-only."
+        )
+
+    # Check for intersections between isolated_modules and other list options
+    conflicts.extend(
+        f"Conflict: {set(isolated_modules).intersection(packages)}. "
+        f"Modules set to --isolated-modules cannot be included in {option}."
+        for option, packages in [
+            ("--import-restrictions", list(import_restrictions.keys())),
+            ("--restricted-packages", restricted_packages),
+            ("--std-lib-only", std_lib_only),
+            ("--third-party-only", third_party_only),
+            ("--first-party-only", first_party_only),
+            ("--project-only", project_only),
+            ("--base-package-only", base_package_only),
+        ]
+        if set(isolated_modules).intersection(packages)
+    )
+
+    # If no conflicts are detected
+    return conflicts or None

--- a/tests/utils/option_utils_test.py
+++ b/tests/utils/option_utils_test.py
@@ -1,0 +1,23 @@
+"""Test the option utils with a sample setting instance"""
+from flake8_custom_import_rules.defaults import Settings
+from flake8_custom_import_rules.utils.option_utils import check_conflicts
+
+
+def test_check_conflicts():
+    """Test the check_conflicts function."""
+    sample_settings = Settings()
+    sample_settings.THIRD_PARTY_ONLY = ["package1", "package2"]
+    sample_settings.FIRST_PARTY_ONLY = ["package2", "package3"]
+    sample_settings.ISOLATED_MODULES = ["module1"]
+    sample_settings.IMPORT_RESTRICTIONS = {
+        "module1": ["submoduleA", "submoduleB"],
+        "module2": ["submoduleC"],
+    }
+
+    check_conflicts(sample_settings.dict)
+
+
+def test_check_conflicts__for_none():
+    """Test the check_conflicts function."""
+    sample_settings = Settings()
+    assert check_conflicts(sample_settings.dict) is None


### PR DESCRIPTION
## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES
Add option_utils.py

""" Utility functions for the flake8-custom-import-rules plugin options. """

```python
def check_conflicts(settings_dict: dict) -> list | None:
    """
    Check for conflicts in the provided settings.

    Parameters
    ----------
    settings_dict : dict
        An instance of the Settings class with the configurations.

    Returns
    -------
    list | None
        A list of messages indicating any conflicts or stating that
        there are no conflicts.
    """

    conflicts = []

    # Extract lists from settings
    restricted_packages = settings_dict.get("RESTRICTED_PACKAGES", [])
    isolated_modules = settings_dict.get("ISOLATED_MODULES", [])
    std_lib_only = settings_dict.get("STD_LIB_ONLY", [])
    third_party_only = settings_dict.get("THIRD_PARTY_ONLY", [])
    first_party_only = settings_dict.get("FIRST_PARTY_ONLY", [])
    project_only = settings_dict.get("PROJECT_ONLY", [])
    base_package_only = settings_dict.get("BASE_PACKAGE_ONLY", [])

    # Extract dict from settings
    import_restrictions = settings_dict.get("IMPORT_RESTRICTIONS", {})

    # Check for intersections among list options
    if conflict := set(third_party_only).intersection(first_party_only):
        conflicts.append(
            f"Conflict: {conflict}. A package cannot be set to both "
            f"--third-party-only and --first-party-only."
        )
    if conflict := set(std_lib_only).intersection(third_party_only):
        conflicts.append(
            f"Conflict: {conflict}. A package cannot be set to both "
            f"--std-lib-only and --third-party-only."
        )

    # Check for intersections between isolated_modules and other list options
    conflicts.extend(
        f"Conflict: {set(isolated_modules).intersection(packages)}. "
        f"Modules set to --isolated-modules cannot be included in {option}."
        for option, packages in [
            ("--import-restrictions", list(import_restrictions.keys())),
            ("--restricted-packages", restricted_packages),
            ("--std-lib-only", std_lib_only),
            ("--third-party-only", third_party_only),
            ("--first-party-only", first_party_only),
            ("--project-only", project_only),
            ("--base-package-only", base_package_only),
        ]
        if set(isolated_modules).intersection(packages)
    )

    # If no conflicts are detected
    return conflicts or None
```
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
