### PR TITLE
fix(import-rules): update isolated modules to account for imports fro…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,10 @@ packages. Specifically, it facilitates the management of lightweight packages
 by limiting their imports to the Python standard library or third-party
 libraries, thus preventing unnecessary dependencies.
 
-Beyond enhancing readability and maintainability, the plugin promotes a modular architecture
-that is easier to comprehend, test, and debug. Consequently, developers can
-smoothly adhere to best practices, maintaining their projects in a clean,
+Beyond enhancing readability and maintainability, the plugin promotes a
+modular architecture that is easier to comprehend, test, and debug.
+Consequently, developers can smoothly adhere to best practices,
+maintaining their projects in a clean,
 organized, and collaborative-friendly state.
 
 
@@ -36,8 +37,8 @@ Install from ``pip`` with:
 
      pip install flake8-custom-import-rules
 
-Options
--------
+Plugin Options
+--------------
 
 Custom Import Rules (CIR) allow you to define and enforce import rules for
 packages within your project. This plugin provides a set of flags that enable
@@ -48,6 +49,7 @@ over your import rules.
 Project Import Rules (PIR) allow you to define and enforce import rules at a project level.
 
 **Restricted Imports**
+~~~~~~~~~~~~~~~~~~~~~~
 
 Use the `--import-restrictions` flag to limit
 specific import capabilities for packages. This
@@ -55,9 +57,14 @@ feature allows you to define a list of packages
 that are restricted from importing certain
 packages or modules within your base package.
 
-Consider a scenario where you're building a data processing application where 'package_a' handles raw data cleaning and 'package_b' carries out sensitive data processing. To avoid accidentally leaking raw data into 'package_b', you might want to prevent 'package_a' from importing 'package_b' or any of its subpackages.
+Consider a scenario where you're building a data processing application
+where 'package_a' handles raw data cleaning and 'package_b' carries
+out sensitive data processing. To avoid accidentally leaking raw
+data into 'package_b', you might want to prevent 'package_a' from
+importing 'package_b' or any of its subpackages.
 
 **Restricted Packages**
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The `--restricted-packages` flag allows you to specify a list of packages that are not permitted to be imported or used by other packages or modules within your base package. This helps maintain a clear separation between high-level and low-level packages.
 
@@ -68,12 +75,14 @@ importing 'lower_level_package' into
 'higher_level_package' to avoid circular dependencies.
 
 **Isolated Packages**
+~~~~~~~~~~~~~~~~~~~~~
 
 The `--isolated-modules` flag allows you to define a list of packages that cannot import from any other packages within your base package. This ensures that certain packages remain standalone and do not introduce unwanted dependencies.
 
 For instance, you might have a 'standalone_package' that performs a specific task independently. To ensure it remains decoupled from the rest of the application, you can make this package isolated.
 
 **Standard Library Only Imports**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `--std-lib-only` flag allows you to specify a set of packages that can only import from the Python standard library. This rule helps to keep specific packages lightweight and free from third-party dependencies.
 
@@ -95,6 +104,7 @@ Remember to carefully assess your project's needs and structure when applying th
 
 
 **Base Package Only Imports**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `--base-package-only` flag allows you to restrict a package to import only from the project's top-level package. This can help maintain a clear hierarchy within your project's package structure.
 
@@ -109,12 +119,27 @@ For example, if you have a package named 'package_h' and you want it to only imp
 In this case, any attempt by 'package_h' to import from other packages will be flagged by the linter.
 
 **Top-level Only Imports**
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `--top-level-only-imports` flag is currently not implemented. Once available, it should allow you to restrict certain packages or modules to only import from the top-level package.
 
 **Import Restriction Flags**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are also several flags available to restrict specific types of imports. These include `--restrict-relative-imports`, `--restrict-local-imports`, `--restrict-conditional-imports`, `--restrict-dynamic-imports`, `--restrict-private-imports`, `--restrict-wildcard-imports`, `--restrict-aliased-imports`, `--restrict-future-imports`, `--restrict-init-imports`, `--restrict-main-imports`, `--restrict-test-imports`, and `--restrict-conftest-imports`.
+There are also several flags available to restrict specific types of imports. These include:
+
+* `--restrict-relative-imports`
+* `--restrict-local-imports`
+* `--restrict-conditional-imports`
+* `--restrict-dynamic-imports`
+* `--restrict-private-imports`
+* `--restrict-wildcard-imports`
+* `--restrict-aliased-imports`
+* `--restrict-future-imports`
+* `--restrict-init-imports`
+* `--restrict-main-imports`
+* `--restrict-test-imports`
+* `--restrict-conftest-imports`.
 
 These flags help maintain clean and clear import structures by preventing certain types of potentially problematic imports. For example, you may want to prevent relative imports, which can make code harder to understand, or wildcard imports, which can pollute the namespace. Each of these flags can be enabled or disabled independently, allowing for fine-grained control over your project's import structure.
 
@@ -130,12 +155,6 @@ With this setting, any relative imports in your project will be flagged by the l
 
 These rules and flags allow you to enforce a clean and understandable structure for your project's imports, making your code more maintainable and less prone to bugs or design issues. Remember to review each flag and its implications carefully, and choose the ones that best suit your project's needs and design.
 
-
-Here is a brief outline of how I will respond:
-
-1. I will explain the purpose of the CustomImportRules class.
-2. I will highlight each of the import restriction flags.
-3. I will provide use cases for each flag.
 
 **CustomImportRules class**
 
@@ -258,7 +277,7 @@ Custom Import Rules (CIR)
 | --restricted         | Restrict a package from importing another package, or modules from another package.           |
 +----------------------+-----------------------------------------------------------------------------------------------+
 
-Custom Import Rules allowed import types
+Custom Import Rules Allowed Import Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-------------------+---------+--------------+-------------+-------------+-------------+
@@ -278,13 +297,15 @@ Custom Import Rules allowed import types
 +-------------------+---------+--------------+-------------+-------------+-------------+
 
 
-.. [#] Technically project imports are "First Party" imports, but in this case we want to make a distinction between the top-level package and the rest of the project.
+.. [#] Technically project imports are "First Party" imports, but in this case we
+    want to make a distinction between the top-level package and the rest of the project.
 .. [#] To restrict future imports, use the `--restrict-future-imports` flag.
 
 Example Configurations
 ----------------------
 
 **.toml file**
+~~~~~~~~~~~~~~~~
 
 .. code-block:: toml
 
@@ -309,6 +330,7 @@ Example Configurations
 
 
 **.ini file**
+~~~~~~~~~~~~~~
 
 .. code-block:: ini
 
@@ -529,7 +551,6 @@ Plugin Limitations
 -   Support for project level exceptions is not implemented yet.
     (e.g., restrict aliased imports but allow import of numpy as np).
 -   Option top-level-only-imports has not been implemented yet.
--   Dynamic string checks are not fully implemented yet. Currently they
 
 License
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 classifiers = [
     "Framework :: Flake8",
-    "Intended Audience :: Developers",
+    "Environment :: Console",
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
@@ -43,10 +43,11 @@ license = "MIT"
 include = ["pyproject.toml", "LICENSE", "CHANGELOG.md"]
 
 [tool.poetry.scripts]
-custom_import_rules = "flake8_custom_import_rules.__main__:main"
+import-rules = "flake8_custom_import_rules.__main__:main"
 
 [tool.poetry.urls]
 "GitHub" = "https://github.com/RodrigoGonzalez/flake8-custom-import-rules"
+"Change Log" = "https://github.com/RodrigoGonzalez/flake8-custom-import-rules/blob/main/CHANGELOG.md"
 
 # from https://python-poetry.org/docs/pyproject/#plugins
 [tool.poetry.plugins."flake8.extension"]

--- a/src/flake8_custom_import_rules/utils/parse_utils.py
+++ b/src/flake8_custom_import_rules/utils/parse_utils.py
@@ -158,27 +158,27 @@ def does_file_match_custom_rule(file_identifier: str, custom_rules: list[str] | 
     return check_string(file_identifier, prefix=tuple(custom_rules), delimiter=" ")
 
 
-def does_import_match_restricted_imports(
-    node_identifier: str, restricted_imports: list[str] | str | None
+def does_import_match_isolated_imports(
+    node_identifier: str, isolated_imports: list[str] | str | None
 ) -> bool:
     """
-    Check if an import identifier is in a restricted import.
+    Check if an import identifier is in an isolated import.
 
     Parameters
     ----------
     node_identifier : str
         The import identifier to check.
-    restricted_imports : list[str] | str | None
-        A list of restricted imports or a single restricted import to check against.
+    isolated_imports : list[str] | str | None
+        A list of isolated imports or a single isolated import to check against.
 
     Returns
     -------
     bool
     """
-    if restricted_imports is None:
+    if isolated_imports is None:
         return False
     restricted_imports = (
-        [restricted_imports] if isinstance(restricted_imports, str) else restricted_imports
+        [isolated_imports] if isinstance(isolated_imports, str) else isolated_imports
     )
     return check_string(node_identifier, prefix=tuple(restricted_imports), delimiter=" ")
 

--- a/tests/test_cases/custom_import_rules/isolated_modules_test.py
+++ b/tests/test_cases/custom_import_rules/isolated_modules_test.py
@@ -21,12 +21,7 @@ CUSTOM_MSG = (
 
 MODULE_THREE_PACKAGE_ERRORS = {
     f"9:0: {CIR301} Using 'import my_base_module.module_y'{CUSTOM_MSG}",
-    f"10:0: {CIR301} Using 'import my_second_base_package.module_one.file_one'{CUSTOM_MSG}",
     f"11:0: {CIR302} Using 'from my_base_module.module_x import X'{CUSTOM_MSG}",
-    (
-        f"12:0: {CIR302} Using 'from my_second_base_package.module_one.file_two import "
-        f"ModuleTwo'{CUSTOM_MSG}"
-    ),
 }
 
 MODULE_THREE_MODULE_ERRORS = {
@@ -50,8 +45,28 @@ MODULE_THREE_MODULE_ERRORS = {
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_three.py",
+            ["my_second_base_package", "my_base_module"],
+            MODULE_THREE_PACKAGE_ERRORS,
+        ),
+        (
+            "example_repos/my_base_module/my_second_base_package/module_three.py",
             ["my_second_base_package.module_three"],
             MODULE_THREE_MODULE_ERRORS,
+        ),
+        (
+            "example_repos/my_base_module/my_second_base_package/module_three.py",
+            ["my_second_base_package.module_three", "my_base_module"],
+            MODULE_THREE_MODULE_ERRORS,
+        ),
+        (
+            "example_repos/my_base_module/my_second_base_package/module_three.py",
+            ["my_second_base_package.module_three", "my_second_base_package.module_one"],
+            MODULE_THREE_MODULE_ERRORS,
+        ),
+        (
+            "example_repos/my_base_module/my_second_base_package/module_three.py",
+            ["my_second_base_package.module_one"],
+            set(),
         ),
     ],
 )

--- a/tests/utils/parse_utils_test.py
+++ b/tests/utils/parse_utils_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from flake8_custom_import_rules.utils.parse_utils import check_string
 from flake8_custom_import_rules.utils.parse_utils import does_file_match_custom_rule
-from flake8_custom_import_rules.utils.parse_utils import does_import_match_restricted_imports
+from flake8_custom_import_rules.utils.parse_utils import does_import_match_isolated_imports
 from flake8_custom_import_rules.utils.parse_utils import parse_module_string
 from flake8_custom_import_rules.utils.parse_utils import retrieve_custom_rule_matches
 
@@ -133,7 +133,7 @@ PACKAGE_6 = [
 
 
 @pytest.mark.parametrize(
-    ("node_identifier", "restricted_imports", "expected"),
+    ("node_identifier", "isolated_imports", "expected"),
     [
         ("my_second_base_package.module_one.file_one", PACKAGE_6, True),
         ("my_second_base_package.module_one.file_two", PACKAGE_6, True),
@@ -146,13 +146,13 @@ PACKAGE_6 = [
         ("my_third_base_package.file", PACKAGE_6, True),
     ],
 )
-def test_does_import_match_restricted_imports(
-    node_identifier: str, restricted_imports: list[str], expected: bool
+def test_does_import_match_isolated_imports(
+    node_identifier: str, isolated_imports: list[str], expected: bool
 ) -> None:
-    """Test does_import_match_restricted_imports."""
+    """Test does_import_match_isolated_imports."""
     assert (
-        does_import_match_restricted_imports(
-            node_identifier=node_identifier, restricted_imports=restricted_imports
+        does_import_match_isolated_imports(
+            node_identifier=node_identifier, isolated_imports=isolated_imports
         )
         == expected
     )


### PR DESCRIPTION
…m package itself
```python
def _check_isolated_imports(self, node: ParsedStraightImport ParsedFromImport) -> bool:
        """Check for isolated imports"""
        return (
            node.import_type == ImportType.FIRST_PARTY
            and not does_import_match_isolated_imports(
                node.identifier,
                retrieve_custom_rule_matches(
                    self.file_identifier, self.checker_settings.ISOLATED_MODULES
                ),
            )
        )
```
## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
