### PR TITLE
refactor(error-codes): update import restriction error codes

### DIFF
--- a/src/flake8_custom_import_rules/codes/error_codes.py
+++ b/src/flake8_custom_import_rules/codes/error_codes.py
@@ -40,10 +40,10 @@ class ErrorCode(Enum, metaclass=ErrorCodeMeta):
 
     # Custom Import Rules: Restricting imports
     CIR101 = "CIR101 Custom import rule conflicts."
-    CIR102 = "CIR102 Restrict package import for specific package or module."
-    CIR103 = "CIR103 Restrict package `from import` for specific package or module."
-    CIR104 = "CIR104 Restrict module import for specific package or module."
-    CIR105 = "CIR105 Restrict module `from import` for specific package or module."
+    CIR102 = "CIR102 Restrict project import for specific package or module."
+    CIR103 = "CIR103 Restrict project `from import` for specific package or module."
+    CIR104 = "CIR104 Restrict non-project import for specific package or module."
+    CIR105 = "CIR105 Restrict non-project `from import` for specific package or module."
     # Restricted package: For example the high level package can `app` is restricted
     CIR106 = "CIR106 Restricted package import."
     CIR107 = "CIR107 Restricted module import."


### PR DESCRIPTION
## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES
Add error codes

    CIR102 = "CIR102 Restrict project import for specific package or module."
    CIR103 = "CIR103 Restrict project `from import` for specific package or module."
    CIR104 = "CIR104 Restrict non-project import for specific package or module."
    CIR105 = "CIR105 Restrict non-project `from import` for specific package or module."

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
