### PR TITLE
refactor(plugin): update plugin to use preprocessed checker settings …

### DIFF
--- a/src/flake8_custom_import_rules/flake8_plugin.py
+++ b/src/flake8_custom_import_rules/flake8_plugin.py
@@ -112,10 +112,14 @@ class Plugin(CustomImportRulesChecker):
             if option_value is not None:
                 options[option_key] = option_value
 
+        # the Settings class will process and parse the options
+        checker_settings = Settings(**options)
+
         parsed_options: dict = {
-            "restricted_packages": options["RESTRICTED_PACKAGES"],
-            "base_packages": options["BASE_PACKAGES"],
-            "checker_settings": Settings(**options),
+            "restricted_packages": checker_settings.RESTRICTED_PACKAGES,
+            "import_restrictions": checker_settings.IMPORT_RESTRICTIONS,
+            "base_packages": checker_settings.BASE_PACKAGES,
+            "checker_settings": checker_settings,
             "test_env": False,
         }
 


### PR DESCRIPTION
…for restricted packages and import restrictions

## RATIONALE

Use Settings to parse imports in plugin.

## CHANGES

```python
        checker_settings = Settings(**options)

        parsed_options: dict = {
            "restricted_packages": checker_settings.RESTRICTED_PACKAGES,
            "import_restrictions": checker_settings.IMPORT_RESTRICTIONS,
            "base_packages": checker_settings.BASE_PACKAGES,
            "checker_settings": checker_settings,
            "test_env": False,
        }

```


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
