### PR TITLE
fix(import-rules): update checks for import restrictions to correctly…

### DIFF
--- a/src/flake8_custom_import_rules/codes/error_codes.py
+++ b/src/flake8_custom_import_rules/codes/error_codes.py
@@ -36,14 +36,18 @@ class ErrorCodeMeta(EnumMeta):
 
 
 class ErrorCode(Enum, metaclass=ErrorCodeMeta):
-    """Error codes for custom import rules."""
+    """Error codes for custom import rules.
+
+    Error codes are used to identify the error and to provide a short
+    description of the error.
+    """
 
     # Custom Import Rules: Restricting imports
     CIR101 = "CIR101 Custom import rule conflicts."
-    CIR102 = "CIR102 Restrict project import for specific package or module."
-    CIR103 = "CIR103 Restrict project `from import` for specific package or module."
-    CIR104 = "CIR104 Restrict non-project import for specific package or module."
-    CIR105 = "CIR105 Restrict non-project `from import` for specific package or module."
+    CIR102 = "CIR102 Import Restriction Violation. Restrict project import."
+    CIR103 = "CIR103 Import Restriction Violation. Restrict project `from import`"
+    CIR104 = "CIR104 Import Restriction Violation. Restrict non-project import."
+    CIR105 = "CIR105 Import Restriction Violation. Restrict non-project `from import`."
     # Restricted package: For example the high level package can `app` is restricted
     CIR106 = "CIR106 Restricted package import."
     CIR107 = "CIR107 Restricted module import."

--- a/src/flake8_custom_import_rules/core/error_messages.py
+++ b/src/flake8_custom_import_rules/core/error_messages.py
@@ -34,6 +34,10 @@ class ErrorMessage:
         self.custom_explanation = self.custom_explanation or ""
         self.message = f"{self.message} {self.custom_explanation}".strip()
 
+    def __str__(self) -> str:
+        """Return the error message."""
+        return f"{self.lineno}:{self.col_offset}: {self.code} {self.message}"
+
 
 def standard_error_message(
     node: ParsedNode,
@@ -172,5 +176,32 @@ def restricted_imports_error(
     custom_explanation = (
         f"Using '{node.import_statement}'. Restricted package/module "
         f"cannot be imported outside package/module."
+    )
+    return standard_error_message(node, error_code, custom_explanation)
+
+
+def import_restriction_error(
+    node: ParsedNode,
+    error_code: ErrorCode,
+    file_identifier: str,
+) -> ErrorMessage:
+    """Generate error message for import restriction.
+
+    Parameters
+    ----------
+    node : ParsedNode
+        The node that caused the error.
+    error_code : ErrorCode
+        The error code.
+    file_identifier : str
+        The file identifier.
+
+    Returns
+    -------
+    ErrorMessage
+    """
+    custom_explanation = (
+        f"Using '{node.import_statement}'. Restricted package/module "
+        f"cannot be imported into module '{file_identifier}'."
     )
     return standard_error_message(node, error_code, custom_explanation)

--- a/src/flake8_custom_import_rules/core/nodes.py
+++ b/src/flake8_custom_import_rules/core/nodes.py
@@ -145,6 +145,16 @@ class DynamicStringParseSyntaxFailure:
     value: str
 
 
+@define(slots=True)
+class HelperParsedImport:
+    """Helper parsed import statement for tests."""
+
+    lineno: int = 0
+    col_offset: int = 0
+    import_statement: str = ""
+    identifier: str = ""
+
+
 ParsedNode = (
     ParsedStraightImport
     | ParsedFromImport
@@ -152,6 +162,7 @@ ParsedNode = (
     | ParsedClassDef
     | ParsedFunctionDef
     | ParsedCall
+    | HelperParsedImport
     | ParsedDynamicImport
     | ParsedIfImport
     | DynamicStringStraightImport

--- a/tests/test_cases/custom_import_rules/import_restrictions_test.py
+++ b/tests/test_cases/custom_import_rules/import_restrictions_test.py
@@ -11,22 +11,28 @@ poetry run python -m pytest -vvvrca tests/test_cases/custom_import_rules/import_
 import ast
 import os
 from collections import defaultdict
+from functools import partial
 
 import pycodestyle
 import pytest
 from flake8.utils import normalize_path
 
 from flake8_custom_import_rules.codes.error_codes import ErrorCode
+from flake8_custom_import_rules.core.error_messages import import_restriction_error
 from flake8_custom_import_rules.core.import_rules import CustomImportRules
+from flake8_custom_import_rules.core.nodes import HelperParsedImport
 from flake8_custom_import_rules.defaults import Settings
 from flake8_custom_import_rules.defaults import convert_to_dict
 from flake8_custom_import_rules.utils.file_utils import get_module_name_from_filename
 from flake8_custom_import_rules.utils.node_utils import root_package_name
 
-CIR102 = ErrorCode.CIR102.full_message
-CIR103 = ErrorCode.CIR103.full_message
-CIR104 = ErrorCode.CIR104.full_message
-CIR105 = ErrorCode.CIR105.full_message
+HPI = partial(HelperParsedImport, col_offset=0)
+CIR101 = partial(import_restriction_error, node=HPI, error_code=ErrorCode.CIR101)
+
+CIR102 = partial(import_restriction_error, node=HPI, error_code=ErrorCode.CIR102)
+CIR103 = partial(import_restriction_error, node=HPI, error_code=ErrorCode.CIR103)
+CIR104 = partial(import_restriction_error, node=HPI, error_code=ErrorCode.CIR104)
+CIR105 = partial(import_restriction_error, node=HPI, error_code=ErrorCode.CIR105)
 
 BASE_EXPECTED_RESTRICTED_IDENTIFIERS = {
     "my_base_module",
@@ -38,7 +44,6 @@ BASE_EXPECTED_RESTRICTED_IDENTIFIERS = {
     "my_base_module.module_two.file_one",
     "my_base_module.module_two.file_two",
     "my_third_base_package",
-    "my_third_base_package.G",
     "my_third_base_package.file",
     "my_third_base_package.module_one",
     "my_third_base_package.module_one.file_one",
@@ -47,8 +52,6 @@ BASE_EXPECTED_RESTRICTED_IDENTIFIERS = {
     "my_third_base_package.module_two.file_one",
     "my_third_base_package.module_two.file_two",
     "uuid",
-    "uuid.UUID",
-    "uuid.uuid4",
 }
 
 
@@ -71,26 +74,113 @@ BASE_EXPECTED_RESTRICTED_IDENTIFIERS = {
                     "my_second_base_package.module_two",
                     "my_second_base_package.module_two.file_one",
                     "my_second_base_package.module_two.file_two",
-                    "my_second_base_package.file.C",
-                    "my_second_base_package.module_one.file_two.B",
-                    "my_second_base_package.module_two.D",
                 }
             ),
-            12,
-            {
-                f"10:0: {CIR102}",
-                f"11:0: {CIR102}",
-                f"14:0: {CIR104}",
-                f"26:0: {CIR103}",
-                f"28:0: {CIR103}",
-                f"29:0: {CIR103}",
-                f"33:0: {CIR103}",
-                f"34:0: {CIR103}",
-                f"3:0: {CIR104}",
-                f"6:0: {CIR102}",
-                f"8:0: {CIR102}",
-                f"9:0: {CIR102}",
-            },
+            18,
+            [
+                CIR104(
+                    node=HPI(lineno=3, import_statement="import uuid"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=6,
+                        import_statement="import my_second_base_package.module_one.file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=8,
+                        import_statement="import my_second_base_package.module_two.file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=9,
+                        import_statement="import my_second_base_package.module_two.file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=10, import_statement="import my_second_base_package.module_two"
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR102(
+                    node=HPI(lineno=11, import_statement="import my_second_base_package.file"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR104(
+                    node=HPI(lineno=14, import_statement="import my_third_base_package"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR105(
+                    node=HPI(lineno=20, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR105(
+                    node=HPI(lineno=21, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=24,
+                        import_statement="from my_second_base_package.module_one.file_two import B",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=26,
+                        import_statement="from my_second_base_package.module_one import file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=28,
+                        import_statement="from my_second_base_package.module_two import file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=29,
+                        import_statement="from my_second_base_package.module_two import file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=30,
+                        import_statement="from my_second_base_package.module_two import D",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=31, import_statement="from my_second_base_package.file import C"
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=33, import_statement="from my_second_base_package import module_two"
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR103(
+                    node=HPI(lineno=34, import_statement="from my_second_base_package import file"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR105(
+                    node=HPI(lineno=37, import_statement="from my_third_base_package import G"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_one/file_two.py",
@@ -102,26 +192,113 @@ BASE_EXPECTED_RESTRICTED_IDENTIFIERS = {
                     "my_second_base_package.module_two",
                     "my_second_base_package.module_two.file_one",
                     "my_second_base_package.module_two.file_two",
-                    "my_second_base_package.file.C",
-                    "my_second_base_package.module_one.file_one.A",
-                    "my_second_base_package.module_two.D",
                 }
             ),
-            12,
-            {
-                f"10:0: {CIR102}",
-                f"11:0: {CIR102}",
-                f"14:0: {CIR104}",
-                f"25:0: {CIR103}",
-                f"28:0: {CIR103}",
-                f"29:0: {CIR103}",
-                f"33:0: {CIR103}",
-                f"34:0: {CIR103}",
-                f"3:0: {CIR104}",
-                f"5:0: {CIR102}",
-                f"8:0: {CIR102}",
-                f"9:0: {CIR102}",
-            },
+            18,
+            [
+                CIR104(
+                    node=HPI(lineno=3, import_statement="import uuid"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=5,
+                        import_statement="import my_second_base_package.module_one.file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=8,
+                        import_statement="import my_second_base_package.module_two.file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=9,
+                        import_statement="import my_second_base_package.module_two.file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=10, import_statement="import my_second_base_package.module_two"
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR102(
+                    node=HPI(lineno=11, import_statement="import my_second_base_package.file"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR104(
+                    node=HPI(lineno=14, import_statement="import my_third_base_package"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR105(
+                    node=HPI(lineno=20, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR105(
+                    node=HPI(lineno=21, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=23,
+                        import_statement="from my_second_base_package.module_one.file_one import A",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=25,
+                        import_statement="from my_second_base_package.module_one import file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=28,
+                        import_statement="from my_second_base_package.module_two import file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=29,
+                        import_statement="from my_second_base_package.module_two import file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=30,
+                        import_statement="from my_second_base_package.module_two import D",
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=31, import_statement="from my_second_base_package.file import C"
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=33, import_statement="from my_second_base_package import module_two"
+                    ),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR103(
+                    node=HPI(lineno=34, import_statement="from my_second_base_package import file"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR105(
+                    node=HPI(lineno=37, import_statement="from my_third_base_package import G"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_two/file_one.py",
@@ -133,27 +310,118 @@ BASE_EXPECTED_RESTRICTED_IDENTIFIERS = {
                     "my_second_base_package.module_one.file_one",
                     "my_second_base_package.module_one.file_two",
                     "my_second_base_package.module_two.file_two",
-                    "my_second_base_package.file.C",
-                    "my_second_base_package.module_one.C",
-                    "my_second_base_package.module_one.file_one.A",
-                    "my_second_base_package.module_one.file_two.B",
                 }
             ),
-            12,
-            {
-                f"11:0: {CIR102}",
-                f"14:0: {CIR104}",
-                f"25:0: {CIR103}",
-                f"26:0: {CIR103}",
-                f"29:0: {CIR103}",
-                f"32:0: {CIR103}",
-                f"34:0: {CIR103}",
-                f"3:0: {CIR104}",
-                f"5:0: {CIR102}",
-                f"6:0: {CIR102}",
-                f"7:0: {CIR102}",
-                f"9:0: {CIR102}",
-            },
+            19,
+            [
+                CIR104(
+                    node=HPI(lineno=3, import_statement="import uuid"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=5,
+                        import_statement="import my_second_base_package.module_one.file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=6,
+                        import_statement="import my_second_base_package.module_one.file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR102(
+                    node=HPI(lineno=7, import_statement="import my_second_base_package.module_one"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=9,
+                        import_statement="import my_second_base_package.module_two.file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR102(
+                    node=HPI(lineno=11, import_statement="import my_second_base_package.file"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR104(
+                    node=HPI(lineno=14, import_statement="import my_third_base_package"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR105(
+                    node=HPI(lineno=20, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR105(
+                    node=HPI(lineno=21, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=23,
+                        import_statement="from my_second_base_package.module_one.file_one import A",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=24,
+                        import_statement="from my_second_base_package.module_one.file_two import B",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=25,
+                        import_statement="from my_second_base_package.module_one import file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=26,
+                        import_statement="from my_second_base_package.module_one import file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=27,
+                        import_statement="from my_second_base_package.module_one import C",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=29,
+                        import_statement="from my_second_base_package.module_two import file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=31, import_statement="from my_second_base_package.file import C"
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=32, import_statement="from my_second_base_package import module_one"
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(lineno=34, import_statement="from my_second_base_package import file"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR105(
+                    node=HPI(lineno=37, import_statement="from my_third_base_package import G"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_two/file_two.py",
@@ -165,27 +433,118 @@ BASE_EXPECTED_RESTRICTED_IDENTIFIERS = {
                     "my_second_base_package.module_one.file_one",
                     "my_second_base_package.module_one.file_two",
                     "my_second_base_package.module_two.file_one",
-                    "my_second_base_package.file.C",
-                    "my_second_base_package.module_one.C",
-                    "my_second_base_package.module_one.file_one.A",
-                    "my_second_base_package.module_one.file_two.B",
                 }
             ),
-            12,
-            {
-                f"11:0: {CIR102}",
-                f"14:0: {CIR104}",
-                f"25:0: {CIR103}",
-                f"26:0: {CIR103}",
-                f"28:0: {CIR103}",
-                f"32:0: {CIR103}",
-                f"34:0: {CIR103}",
-                f"3:0: {CIR104}",
-                f"5:0: {CIR102}",
-                f"6:0: {CIR102}",
-                f"7:0: {CIR102}",
-                f"8:0: {CIR102}",
-            },
+            19,
+            [
+                CIR104(
+                    node=HPI(lineno=3, import_statement="import uuid"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=5,
+                        import_statement="import my_second_base_package.module_one.file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=6,
+                        import_statement="import my_second_base_package.module_one.file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR102(
+                    node=HPI(lineno=7, import_statement="import my_second_base_package.module_one"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=8,
+                        import_statement="import my_second_base_package.module_two.file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR102(
+                    node=HPI(lineno=11, import_statement="import my_second_base_package.file"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR104(
+                    node=HPI(lineno=14, import_statement="import my_third_base_package"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR105(
+                    node=HPI(lineno=20, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR105(
+                    node=HPI(lineno=21, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=23,
+                        import_statement="from my_second_base_package.module_one.file_one import A",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=24,
+                        import_statement="from my_second_base_package.module_one.file_two import B",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=25,
+                        import_statement="from my_second_base_package.module_one import file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=26,
+                        import_statement="from my_second_base_package.module_one import file_two",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=27,
+                        import_statement="from my_second_base_package.module_one import C",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=28,
+                        import_statement="from my_second_base_package.module_two import file_one",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=31, import_statement="from my_second_base_package.file import C"
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=32, import_statement="from my_second_base_package import module_one"
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR103(
+                    node=HPI(lineno=34, import_statement="from my_second_base_package import file"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR105(
+                    node=HPI(lineno=37, import_statement="from my_third_base_package import G"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/file.py",
@@ -193,44 +552,170 @@ BASE_EXPECTED_RESTRICTED_IDENTIFIERS = {
             BASE_EXPECTED_RESTRICTED_IDENTIFIERS.union(
                 {
                     "my_second_base_package.module_one",
-                    "my_second_base_package.module_one.C",
                     "my_second_base_package.module_one.file_one",
-                    "my_second_base_package.module_one.file_one.A",
                     "my_second_base_package.module_one.file_two",
-                    "my_second_base_package.module_one.file_two.B",
                     "my_second_base_package.module_two",
-                    "my_second_base_package.module_two.D",
                     "my_second_base_package.module_two.file_one",
                     "my_second_base_package.module_two.file_two",
                 }
             ),
-            14,
-            {
-                f"10:0: {CIR102}",
-                f"14:0: {CIR104}",
-                f"25:0: {CIR103}",
-                f"26:0: {CIR103}",
-                f"28:0: {CIR103}",
-                f"29:0: {CIR103}",
-                f"32:0: {CIR103}",
-                f"33:0: {CIR103}",
-                f"3:0: {CIR104}",
-                f"5:0: {CIR102}",
-                f"6:0: {CIR102}",
-                f"7:0: {CIR102}",
-                f"8:0: {CIR102}",
-                f"9:0: {CIR102}",
-            },
+            21,
+            [
+                CIR104(
+                    node=HPI(lineno=3, import_statement="import uuid"),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=5,
+                        import_statement="import my_second_base_package.module_one.file_one",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=6,
+                        import_statement="import my_second_base_package.module_one.file_two",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR102(
+                    node=HPI(lineno=7, import_statement="import my_second_base_package.module_one"),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=8,
+                        import_statement="import my_second_base_package.module_two.file_one",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=9,
+                        import_statement="import my_second_base_package.module_two.file_two",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR102(
+                    node=HPI(
+                        lineno=10, import_statement="import my_second_base_package.module_two"
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR104(
+                    node=HPI(lineno=14, import_statement="import my_third_base_package"),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR105(
+                    node=HPI(lineno=20, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR105(
+                    node=HPI(lineno=21, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=23,
+                        import_statement="from my_second_base_package.module_one.file_one import A",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=24,
+                        import_statement="from my_second_base_package.module_one.file_two import B",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=25,
+                        import_statement="from my_second_base_package.module_one import file_one",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=26,
+                        import_statement="from my_second_base_package.module_one import file_two",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=27,
+                        import_statement="from my_second_base_package.module_one import C",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=28,
+                        import_statement="from my_second_base_package.module_two import file_one",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=29,
+                        import_statement="from my_second_base_package.module_two import file_two",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=30,
+                        import_statement="from my_second_base_package.module_two import D",
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=32, import_statement="from my_second_base_package import module_one"
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=33, import_statement="from my_second_base_package import module_two"
+                    ),
+                    file_identifier="my_second_base_package.file",
+                ),
+                CIR105(
+                    node=HPI(lineno=37, import_statement="from my_third_base_package import G"),
+                    file_identifier="my_second_base_package.file",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_three.py",
             "my_second_base_package.module_three",
             BASE_EXPECTED_RESTRICTED_IDENTIFIERS,
-            2,
-            {
-                f"14:0: {CIR104}",
-                f"3:0: {CIR104}",
-            },
+            5,
+            [
+                CIR104(
+                    node=HPI(lineno=3, import_statement="import uuid"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+                CIR104(
+                    node=HPI(lineno=14, import_statement="import my_third_base_package"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+                CIR105(
+                    node=HPI(lineno=20, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+                CIR105(
+                    node=HPI(lineno=21, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+                CIR105(
+                    node=HPI(lineno=37, import_statement="from my_third_base_package import G"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+            ],
         ),
     ],
 )
@@ -239,7 +724,7 @@ def test_complex_imports(
     expected_current_module: str,
     expected_restricted_identifiers: set,
     expected: int,
-    expected_errors: set[str],
+    expected_errors: list[str],
     get_base_plugin: callable,
     custom_import_rules_fixture: str,
     package_10: list[str],
@@ -278,7 +763,7 @@ def test_complex_imports(
     errors = plugin.errors
     assert isinstance(errors, list)
     assert len(errors) == expected
-    assert plugin.errors_set == expected_errors
+    assert plugin.errors_set == {str(error) for error in expected_errors}, sorted(plugin.errors_set)
 
 
 @pytest.mark.parametrize(
@@ -286,23 +771,88 @@ def test_complex_imports(
     [
         (
             "example_repos/my_base_module/my_second_base_package/module_one/file_one.py",
-            set(),
+            [
+                CIR105(
+                    node=HPI(lineno=3, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+                CIR105(
+                    node=HPI(lineno=4, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_one.file_one",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_one/file_two.py",
-            set(),
+            [
+                CIR105(
+                    node=HPI(lineno=3, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+                CIR105(
+                    node=HPI(lineno=4, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_one.file_two",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_two/file_one.py",
-            {f"2:0: {CIR104}"},
+            [
+                CIR104(
+                    node=HPI(lineno=2, import_statement="import uuid"),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=10,
+                        import_statement="from my_second_base_package.module_one.file_two import "
+                        "ModuleTwo",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+                CIR103(
+                    node=HPI(
+                        lineno=11,
+                        import_statement="from my_second_base_package.module_two.file_two "
+                        "import ModuleTwoFileTwo",
+                    ),
+                    file_identifier="my_second_base_package.module_two.file_one",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_two/file_two.py",
-            set(),
+            [
+                CIR105(
+                    node=HPI(lineno=3, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+                CIR105(
+                    node=HPI(lineno=4, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_two.file_two",
+                ),
+            ],
         ),
         (
             "example_repos/my_base_module/my_second_base_package/module_three.py",
-            set(),
+            [
+                CIR104(
+                    node=HPI(lineno=9, import_statement="import my_base_module.module_y"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+                CIR105(
+                    node=HPI(lineno=11, import_statement="from my_base_module.module_x import X"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+                CIR105(
+                    node=HPI(lineno=3, import_statement="from uuid import UUID"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+                CIR105(
+                    node=HPI(lineno=4, import_statement="from uuid import uuid4"),
+                    file_identifier="my_second_base_package.module_three",
+                ),
+            ],
         ),
     ],
 )
@@ -333,7 +883,7 @@ def test_import_restrictions(
     actual = get_flake8_linter_results(
         s="".join(lines), options=options, delimiter="\n", filename=filename
     )
-    assert set(actual) == expected, sorted(actual)
+    assert set(actual) == {str(error) for error in expected}, sorted(actual)
 
 
 def test_import_restrictions_import_settings_do_not_error(


### PR DESCRIPTION
… identify restricted imports

The following was necessary and was missing in the original:     

```python
def _check_if_import_restriction(self, node: ParsedNode) -> bool:
        """Check if import is restricted."""
        if not does_import_match_custom_import_restriction(
            node.identifier, list(self.restricted_identifiers.keys())
        ):
            return False

        matches = retrieve_custom_rule_matches(
            node.identifier, list(self.restricted_identifiers.keys())
        )
        return any(
            self.restricted_identifiers[match]["import_restriction"] is True for match in matches
        )
```
## RATIONALE

- we were not checking for certain identifiers so some from imports were not being flagged.
- 
## CHANGES
- update import rules
- error messages
- add helper node
- and update tests.
- 
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
