### PR TITLE
fix(import-rules): update restricted packages to correctly identify t…

### DIFF
--- a/src/flake8_custom_import_rules/codes/error_codes.py
+++ b/src/flake8_custom_import_rules/codes/error_codes.py
@@ -44,13 +44,13 @@ class ErrorCode(Enum, metaclass=ErrorCodeMeta):
 
     # Custom Import Rules: Restricting imports
     CIR101 = "CIR101 Custom import rule conflicts."
-    CIR102 = "CIR102 Import Restriction Violation. Restrict project import."
-    CIR103 = "CIR103 Import Restriction Violation. Restrict project `from import`"
-    CIR104 = "CIR104 Import Restriction Violation. Restrict non-project import."
-    CIR105 = "CIR105 Import Restriction Violation. Restrict non-project `from import`."
+    CIR102 = "CIR102 Import Restriction Violation. Restricted project import."
+    CIR103 = "CIR103 Import Restriction Violation. Restricted project `from import`"
+    CIR104 = "CIR104 Import Restriction Violation. Restricted non-project import."
+    CIR105 = "CIR105 Import Restriction Violation. Restricted non-project `from import`."
     # Restricted package: For example the high level package can `app` is restricted
-    CIR106 = "CIR106 Restricted package import."
-    CIR107 = "CIR107 Restricted module import."
+    CIR106 = "CIR106 Restricted Package Violation. Restricted project import."
+    CIR107 = "CIR107 Restricted Package Violation. Restricted project `from import`."
 
     # Project only imports. No packages and modules from outside your project
     # (i.e. No Third Party Imports)

--- a/src/flake8_custom_import_rules/core/error_messages.py
+++ b/src/flake8_custom_import_rules/core/error_messages.py
@@ -156,9 +156,10 @@ def first_party_only_error(
     return standard_error_message(node, error_code, custom_explanation)
 
 
-def restricted_imports_error(
+def restricted_package_error(
     node: ParsedNode,
     error_code: ErrorCode,
+    file_identifier: str,
 ) -> ErrorMessage:
     """Generate error message for restricted imports.
 
@@ -168,14 +169,16 @@ def restricted_imports_error(
         The node that caused the error.
     error_code : ErrorCode
         The error code.
+    file_identifier : str
+        The file identifier.
 
     Returns
     -------
     ErrorMessage
     """
     custom_explanation = (
-        f"Using '{node.import_statement}'. Restricted package/module "
-        f"cannot be imported outside package/module."
+        f"Using '{node.import_statement}'. Restricted package "
+        f"cannot be imported into module '{file_identifier}'."
     )
     return standard_error_message(node, error_code, custom_explanation)
 

--- a/tests/test_cases/custom_import_rules/import_restrictions_test.py
+++ b/tests/test_cases/custom_import_rules/import_restrictions_test.py
@@ -27,7 +27,6 @@ from flake8_custom_import_rules.utils.file_utils import get_module_name_from_fil
 from flake8_custom_import_rules.utils.node_utils import root_package_name
 
 HPI = partial(HelperParsedImport, col_offset=0)
-CIR101 = partial(import_restriction_error, node=HPI, error_code=ErrorCode.CIR101)
 
 CIR102 = partial(import_restriction_error, node=HPI, error_code=ErrorCode.CIR102)
 CIR103 = partial(import_restriction_error, node=HPI, error_code=ErrorCode.CIR103)


### PR DESCRIPTION
…he packages and modules and subpackages that need to be restricted

The following function was updated as well as the tests:     

```python
def _check_if_restricted_package(self, node: ParsedNode) -> bool:
        """Check if restricted package."""
        logging.debug(
            f"Node import_statement: `{node.import_statement}`, "
            f"import_type: {node.import_type}, "
            f"module: `{node.module}`,"
        )
        if not does_import_match_custom_import_restriction(
            node.identifier, list(self.restricted_identifiers.keys())
        ):
            return False

        matches = retrieve_custom_rule_matches(
            node.identifier, list(self.restricted_identifiers.keys())
        )
        return any(
            self.restricted_identifiers[match]["restricted_package"] is True for match in matches
        )
```

## RATIONALE

Incorrectly determining restricted packages

## CHANGES
- update import rules
- update corresponding tests
- update error messages

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
