### PR TITLE
refactor(restricted-import-visitor): remove check module exists optio…

### DIFF
--- a/src/flake8_custom_import_rules/core/restricted_import_visitor.py
+++ b/src/flake8_custom_import_rules/core/restricted_import_visitor.py
@@ -1,14 +1,11 @@
 """ Visitor for parsing restricted imports. """
 import ast
 import logging
-import os
 from collections import defaultdict
 
 from attrs import define
 from attrs import field
 
-from flake8_custom_import_rules.utils.file_utils import get_file_path_from_module_name
-from flake8_custom_import_rules.utils.file_utils import get_relative_path_from_absolute_path
 from flake8_custom_import_rules.utils.node_utils import get_package_names
 from flake8_custom_import_rules.utils.node_utils import root_package_name
 from flake8_custom_import_rules.utils.restricted_import_utils import get_import_restriction_strings
@@ -32,8 +29,6 @@ class RestrictedImportVisitor(ast.NodeVisitor):
         List of restricted packages that are not allowed to be imported.
     _import_restrictions: defaultdict[str, list[str]]
         Default dictionary containing import restrictions for specific packages.
-    _check_module_exists: bool
-        Flag to check if the module exists (not implemented). Default is True.
     _file_packages: list[str]
         List of file packages to check. Default is an empty list.
     _restrictions: list[str]
@@ -54,7 +49,6 @@ class RestrictedImportVisitor(ast.NodeVisitor):
     _restricted_package_list: list[str] = field(init=False)
     _import_restrictions: defaultdict[str, list[str]]
     _import_restriction_list: list[str] = field(init=False)
-    _check_module_exists: bool = field(default=True)  # Not Implemented
     _file_packages: list[str] = field(default=list)
     _restrictions: list[str] = field(init=False)
     _lines: list[str] = field(init=False)
@@ -67,9 +61,6 @@ class RestrictedImportVisitor(ast.NodeVisitor):
         """
         Initialize the RestrictedImportVisitor by preparing the restrictions,
         lines, AST tree, and restricted identifiers.
-
-        NOTE: Also, disables the check for module existence as it is not
-        implemented.
         """
 
         self._restricted_package_list = self._get_restricted_package_strings()
@@ -81,10 +72,6 @@ class RestrictedImportVisitor(ast.NodeVisitor):
         self._lines = get_import_strings(self._restrictions)
         self._tree = ast.parse("".join(self._lines))
         self.restricted_identifiers = defaultdict(lambda: defaultdict(str))
-
-        # Not Implemented
-        # TODO: Implement checking if modules exist
-        self._check_module_exists = False
 
     def _get_restricted_package_strings(self) -> list[str]:
         """
@@ -130,38 +117,14 @@ class RestrictedImportVisitor(ast.NodeVisitor):
             restricted_package = module in self._restricted_package_list
             import_restriction = module in self._import_restriction_list
 
-            if self._check_module_exists:  # Not Implemented
-                absolute_path = get_file_path_from_module_name(module)
-                relative_path = (
-                    get_relative_path_from_absolute_path(absolute_path, os.getcwd())
-                    if absolute_path
-                    else None
-                )
-
-                logging.debug(f"Module: {module}")
-                logging.debug(f"Absolute path: {absolute_path}")
-                logging.debug(f"Current working directory: {os.getcwd()}")
-
-                identifier_dict = {
-                    "module": module,
-                    "package": package,
-                    "package_names": package_names,
-                    "import_statement": ast.unparse(node),
-                    "absolute_path": absolute_path,
-                    "relative_path": relative_path,
-                    "restricted_package": restricted_package,
-                    "import_restriction": import_restriction,
-                }
-
-            else:
-                identifier_dict = {
-                    "module": module,
-                    "package": package,
-                    "package_names": package_names,
-                    "import_statement": ast.unparse(node),
-                    "restricted_package": restricted_package,
-                    "import_restriction": import_restriction,
-                }
+            identifier_dict = {
+                "module": module,
+                "package": package,
+                "package_names": package_names,
+                "import_statement": ast.unparse(node),
+                "restricted_package": restricted_package,
+                "import_restriction": import_restriction,
+            }
 
             self.restricted_identifiers[module].update(identifier_dict)
             self._package_names.extend(package_names[:-1])
@@ -186,7 +149,6 @@ def get_restricted_identifiers(
     base_packages: list[str],
     restricted_packages: list[str] | str,
     import_restrictions: defaultdict[str, list[str]] | None = None,
-    check_module_exists: bool = True,  # Not Implemented
     file_packages: list | None = None,
 ) -> defaultdict[str, dict]:
     """
@@ -200,8 +162,6 @@ def get_restricted_identifiers(
         The list of restricted imports.
     import_restrictions : defaultdict[str, list[str]], optional
         The list of restricted imports, by default None
-    check_module_exists : bool, optional
-        Whether to check if the module exists, by default True
     file_packages : list[str], optional
         The list of parent packages of the file, by default None
 
@@ -221,7 +181,6 @@ def get_restricted_identifiers(
         base_packages=base_packages,
         restricted_packages=restricted_packages,
         import_restrictions=import_restrictions,
-        check_module_exists=check_module_exists,  # Not Implemented
         file_packages=file_packages,
     )
     return visitor.get_restricted_identifiers()

--- a/src/flake8_custom_import_rules/core/rules_checker.py
+++ b/src/flake8_custom_import_rules/core/rules_checker.py
@@ -153,7 +153,6 @@ class CustomImportRulesChecker:
                 base_packages=self.options.get("base_packages", []),
                 restricted_packages=self.options.get("restricted_packages", []),
                 import_restrictions=self.options.get("import_restrictions", defaultdict(list)),
-                check_module_exists=False,  # Not Implemented
                 file_packages=self.visitor.file_packages,
             )
         logger.debug(f"Restricted Identifiers: {self._restricted_identifiers}")

--- a/tests/core/restricted_import_visitor_test.py
+++ b/tests/core/restricted_import_visitor_test.py
@@ -25,19 +25,17 @@ RESTRICTED_IMPORTS = [
 
 
 @pytest.mark.parametrize(
-    ("restricted_imports", "check_module_exists", "expected"),
-    [(RESTRICTED_IMPORTS, True, {}), (RESTRICTED_IMPORTS, False, {}), ([], True, {})],
+    ("restricted_imports", "expected"),
+    [(RESTRICTED_IMPORTS, {}), ([], {})],
 )
 def test_get_restricted_identifiers(
     restricted_imports: list[str] | str,
-    check_module_exists: bool,
     expected: dict,
 ) -> None:
     """Test get_restricted_identifiers."""
     restricted_identifiers = get_restricted_identifiers(
         base_packages=[],
         restricted_packages=restricted_imports,
-        check_module_exists=check_module_exists,
     )
     assert isinstance(restricted_identifiers, defaultdict)
 
@@ -123,7 +121,6 @@ def test_restricted_import_visitor(
     """Test get_restricted_identifiers."""
     restricted_import_visitor = RestrictedImportVisitor(
         restricted_packages=RESTRICTED_IMPORTS,
-        check_module_exists=True,
         import_restrictions=defaultdict(list),
         file_packages=get_package_names(file_package),
     )
@@ -234,7 +231,6 @@ def test_get_restricted_identifiers__import_restrictions(
     restricted_identifiers = get_restricted_identifiers(
         base_packages=[],
         restricted_packages=[],
-        check_module_exists=False,
         import_restrictions=convert_to_dict(IMPORT_RESTRICTIONS),
         file_packages=get_package_names(file_package),
     )
@@ -865,7 +861,6 @@ def test_get_restricted_identifiers__import_restrictions_two(
     restricted_identifiers = get_restricted_identifiers(
         base_packages=[],
         restricted_packages=[],
-        check_module_exists=False,
         import_restrictions=convert_to_dict(package_8),
         file_packages=get_package_names(file_package),
     )
@@ -1549,7 +1544,6 @@ def test_get_restricted_identifiers__restricted_identifiers(
     restricted_identifiers = get_restricted_identifiers(
         base_packages=[],
         restricted_packages=package_9,
-        check_module_exists=False,
         import_restrictions=convert_to_dict(package_8),
         file_packages=get_package_names(file_package),
     )


### PR DESCRIPTION
…n from the restricted import visitor class, not used and unnecessary

## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES

- remove `check_module_exists` from everywhere, it is unnecessary and was unused

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
