### PR TITLE
refactor(isolated-packages-flag): renamed isolated modules flag to st…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@
 
 ### Feat
 
-- **isolated-modules**: add test cases (#62)
+- **standalone-modules**: add test cases (#62)
 - **parse-utils**: add module to filename helpers (#61)
 - **project-imports**: added support for non-base and non-first party (#60)
 - **first-party**: updated first party to include base package (#59)

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ organization across their Python projects.
 
 This plugin takes advantage of ``flake8`` linting
 capabilities and provides set of flags that enable you to
-specify import restrictions, isolated packages and modules,
+specify import restrictions, standalone packages and modules,
 and additional custom and project-level import rules.
 These flags can be used in conjunction
 with each other to provide granular control over your import rules.
@@ -22,7 +22,7 @@ with each other to provide granular control over your import rules.
 
 This ``flake8`` plugin significantly enhances the organization
 and consistency of imports in Python projects. By enabling
-developers to set custom restrictions, define isolated packages,
+developers to set custom restrictions, define standalone packages,
 and establish import rules, the plugin aids in mitigating
 unwanted dependencies and maintaining clear separations between
 packages. Specifically, it facilitates the management of
@@ -86,14 +86,14 @@ first_party_only            This flag enforces that only first-party
                             be used in a project where third-party
                             dependencies are intended to be minimized.
 
-isolated_module             This flag enforces that only modules that
-                            are marked as 'isolated' can be imported.
+standalone_module             This flag enforces that only modules that
+                            are marked as 'standalone' can be imported.
                             This could be used in a project where
                             certain modules are intended to be used
                             independently of the rest of the project.
 
-isolated_package            This flag enforces that only packages that
-                            are marked as 'isolated' can be imported.
+standalone_package            This flag enforces that only packages that
+                            are marked as 'standalone' can be imported.
                             This could be used in a project where
                             certain packages are intended to be used
                             independently of the rest of the project.
@@ -138,7 +138,7 @@ restricted_packages         This flag enforces that certain specified
  --third-party-only     Restrict package to import only from third-party
                         libraries.
 
- --isolated             Make a package isolated, so it cannot import
+ --standalone             Make a package standalone, so it cannot import
                         from any other packages within the base package.
 
  --restricted           Restrict a package from importing another
@@ -182,10 +182,10 @@ that handles business logic, you might want to restrict
 importing 'lower_level_package' into
 'higher_level_package' to avoid circular dependencies.
 
-Isolated Packages
-~~~~~~~~~~~~~~~~~
+Standalone Modules
+~~~~~~~~~~~~~~~~~~
 
-The `--isolated-modules` flag allows you to define a list of
+The `--standalone-modules` flag allows you to define a list of
 packages that cannot import from any other packages within
 your base package. This ensures that certain packages remain
 standalone and do not introduce unwanted dependencies.
@@ -193,7 +193,7 @@ standalone and do not introduce unwanted dependencies.
 For instance, you might have a 'standalone_package' that
 performs a specific task independently. To ensure it remains
 decoupled from the rest of the application, you can make
-this package isolated.
+this package standalone.
 
 Standard Library Only Imports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -253,21 +253,21 @@ packages will be flagged by the linter.
 Custom Import Rules: Import Rules and Import Types Table
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-------------------+---------+--------------+-------------+-------------+-------------+
-| RULE              | STD LIB | PROJECT [#]_ | FIRST PARTY | THIRD PARTY | FUTURE [#]_ |
-+===================+=========+==============+=============+=============+=============+
-| std_lib_only      | X       |              |             |             | X           |
-+-------------------+---------+--------------+-------------+-------------+-------------+
-| project_only      | X       | X            | X           |             | X           |
-+-------------------+---------+--------------+-------------+-------------+-------------+
-| base_package_only | X       | X            |             |             | X           |
-+-------------------+---------+--------------+-------------+-------------+-------------+
-| first_party_only  | X       |              | X           |             | X           |
-+-------------------+---------+--------------+-------------+-------------+-------------+
-| third_party_only  | X       |              |             | X           | X           |
-+-------------------+---------+--------------+-------------+-------------+-------------+
-| isolated [#]_     | X       | X            |             | X           | X           |
-+-------------------+---------+--------------+-------------+-------------+-------------+
++--------------------------+---------+--------------+-------------+-------------+-------------+
+| RULE                     | STD LIB | PROJECT [#]_ | FIRST PARTY | THIRD PARTY | FUTURE [#]_ |
++==========================+=========+==============+=============+=============+=============+
+| std_lib_only             | X       |              |             |             | X           |
++--------------------------+---------+--------------+-------------+-------------+-------------+
+| project_only             | X       | X            | X           |             | X           |
++--------------------------+---------+--------------+-------------+-------------+-------------+
+| base_package_only        | X       | X            |             |             | X           |
++--------------------------+---------+--------------+-------------+-------------+-------------+
+| first_party_only         | X       |              | X           |             | X           |
++--------------------------+---------+--------------+-------------+-------------+-------------+
+| third_party_only         | X       |              |             | X           | X           |
++--------------------------+---------+--------------+-------------+-------------+-------------+
+| standalone_modules [#]_  | X       | X            |             | X           | X           |
++--------------------------+---------+--------------+-------------+-------------+-------------+
 
 
 .. [#] Technically project imports are "First Party" imports,
@@ -275,8 +275,8 @@ Custom Import Rules: Import Rules and Import Types Table
     the top-level package and the rest of the project.
 .. [#] To restrict future imports, use the
     `--restrict-future-imports` flag.
-.. [#] The difference between third-party only and isolated,
-    is that isolated allows imports from within the isolated
+.. [#] The difference between third-party only and standalone,
+    is that standalone allows imports from within the standalone
     module/package, while third-party only does not.
 
 
@@ -469,11 +469,11 @@ helps maintain a clear separation between high-level and low-level packages.
 
 Example: Restrict importing 'lower_level_package' into 'higher_level_package'.
 
-Isolated packages: Define a list of packages that cannot import from any other
+Standalone packages: Define a list of packages that cannot import from any other
 packages within your base package. This ensures that certain packages remain
 standalone and do not introduce unwanted dependencies.
 
-Example: Make 'standalone_package' isolated, so it cannot import from any
+Example: Make 'standalone_package' standalone, so it cannot import from any
 other packages within the base package.
 
 Standard library only imports: Specify a set of packages that can only import
@@ -512,8 +512,8 @@ your config file can be named in either of two ways:
         my_base_package.module_x:my_base_package.module_y
     restricted-packages = my_base_package.package_b
 
-    # Make `package_c` an isolated package
-    isolated-modules = my_base_package.package_c
+    # Make `package_c` a standalone package
+    standalone-modules = my_base_package.package_c
 
     # Allow `package_d` to import only from the standard library
     std-lib-only = my_base_package.package_d
@@ -534,7 +534,7 @@ import_restrictions = [
     "my_base_package.module_x:my_base_package.module_y",
 ]
 
-isolated_modules = ["my_base_package.package_c"]
+standalone_modules = ["my_base_package.package_c"]
 
 std_lib_only = ["my_base_package.package_d"]
 
@@ -600,21 +600,21 @@ project_only = ["my_base_package.package_g"]
                         party module, which is not allowed when the
                         **--first-party-only** rule is enabled.
 
-  **CIR301**            This error signifies an import from an isolated
-                        package, which is not allowed when the isolated
+  **CIR301**            This error signifies an import from a standalone
+                        package, which is not allowed when the standalone
                         rule is enabled.
 
   **CIR302**            This error signifies a from import from an
-                        isolated package, which is not allowed when the
-                        isolated rule is enabled.
+                        standalone package, which is not allowed when the
+                        standalone rule is enabled.
 
-  **CIR303**            This error signifies an import from an isolated
-                        module, which is not allowed when the isolated
+  **CIR303**            This error signifies an import from a standalone
+                        module, which is not allowed when the standalone
                         rule is enabled.
 
   **CIR304**            This error signifies a from import from an
-                        isolated module, which is not allowed when the
-                        isolated rule is enabled.
+                        standalone module, which is not allowed when the
+                        standalone rule is enabled.
 
   **CIR401**            This error signifies an import from a non-standard
                         library package, which is not allowed when the

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ maintain clean and consistent import organization across their Python projects.
 
 This ``flake8`` plugin is extremely useful for enforcing custom import rules and
 maintaining a consistent import organization across Python projects. By
-allowing users to define specific restrictions, isolated packages, and import
+allowing users to define specific restrictions, standalone packages, and import
 rules, this plugin helps to prevent unwanted dependencies and ensures a clear
 separation between high-level and low-level packages. Furthermore, it aids in
 managing lightweight packages by restricting them to import only from the

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ select = E,W,F,N,CIR,PIR
 
 # flake8-custom-import-rules
 base-packages = flake8_custom_import_rules, my_base_module
-isolated-modules = flake8_custom_import_rules.utils
+standalone-modules = flake8_custom_import_rules.utils

--- a/src/flake8_custom_import_rules/codes/error_codes.py
+++ b/src/flake8_custom_import_rules/codes/error_codes.py
@@ -61,12 +61,12 @@ class ErrorCode(Enum, metaclass=ErrorCodeMeta):
     CIR205 = "CIR205 Non-first party package import."
     CIR206 = "CIR206 Non-first party module import."
 
-    # Isolated package: Package/module that can not import from any other package in your project.
+    # Standalone package: Package/module that can not import from any other package in your project.
     # Standalone package.
-    CIR301 = "CIR301 Isolated package, imports from project disabled."
-    CIR302 = "CIR302 Isolated package, from imports from project disabled."
-    CIR303 = "CIR303 Isolated module, imports from project disabled."
-    CIR304 = "CIR304 Isolated module, from imports from project disabled."
+    CIR301 = "CIR301 Standalone package, imports from project disabled."
+    CIR302 = "CIR302 Standalone package, from imports from project disabled."
+    CIR303 = "CIR303 Standalone module, imports from project disabled."
+    CIR304 = "CIR304 Standalone module, from imports from project disabled."
 
     # Standard library only import in specified packages or modules
     CIR401 = "CIR401 Non-standard library package import."

--- a/src/flake8_custom_import_rules/core/error_messages.py
+++ b/src/flake8_custom_import_rules/core/error_messages.py
@@ -69,14 +69,14 @@ def standard_error_message(
     )
 
 
-def isolated_imports_error(
+def standalone_imports_error(
     node: ParsedNode,
     error_code: ErrorCode,
     file_identifier: str,
 ) -> ErrorMessage:
-    """Generate error message for isolated imports."""
+    """Generate error message for standalone imports."""
     custom_explanation = (
-        f"Using '{node.import_statement}'. Isolated module '{file_identifier}' "
+        f"Using '{node.import_statement}'. Standalone module '{file_identifier}' "
         f"cannot import from project packages."
     )
     return standard_error_message(node, error_code, custom_explanation)

--- a/src/flake8_custom_import_rules/defaults.py
+++ b/src/flake8_custom_import_rules/defaults.py
@@ -50,7 +50,7 @@ CUSTOM_IMPORT_RULES = [
     "BASE_PACKAGES",
     "IMPORT_RESTRICTIONS",
     "RESTRICTED_PACKAGES",
-    "ISOLATED_MODULES",
+    "STANDALONE_MODULES",
     "STD_LIB_ONLY",
     "THIRD_PARTY_ONLY",
     "FIRST_PARTY_ONLY",
@@ -138,7 +138,7 @@ class Settings:
     BASE_PACKAGES: list = field(factory=list, converter=convert_to_list)
     IMPORT_RESTRICTIONS: defaultdict[str, list] = field(factory=dict, converter=convert_to_dict)
     RESTRICTED_PACKAGES: list = field(factory=list, converter=convert_to_list)
-    ISOLATED_MODULES: list = field(factory=list, converter=convert_to_list)
+    STANDALONE_MODULES: list = field(factory=list, converter=convert_to_list)
     STD_LIB_ONLY: list = field(factory=list, converter=convert_to_list)
     THIRD_PARTY_ONLY: list = field(factory=list, converter=convert_to_list)
     FIRST_PARTY_ONLY: list = field(factory=list, converter=convert_to_list)
@@ -211,7 +211,7 @@ HELP_STRINGS = {
         "This rule helps maintain a clear dependency scope for the specified "
         "packages."
     ),
-    "isolated-modules": (
+    "standalone-modules": (
         "This option allows you to define a list of modules that cannot import "
         "from any other modules within your base package. This ensures that "
         "certain modules remain standalone and do not introduce unwanted "
@@ -254,7 +254,7 @@ ERROR_CODES = {
     "base-package-only": "CIR203 and CIR204",
     "first-party-only": "CIR205 and CIR206",
     "third-party-only": "CIR501 and CIR502",
-    "isolated-modules": "CIR301 to CIR304",
+    "standalone-modules": "CIR301 to CIR304",
     "top-level-only-imports": "PIR101",
     "restrict-relative-imports": "PIR102",
     "restrict-local-imports": "PIR103",

--- a/src/flake8_custom_import_rules/utils/option_utils.py
+++ b/src/flake8_custom_import_rules/utils/option_utils.py
@@ -21,7 +21,7 @@ def check_conflicts(settings_dict: dict) -> list | None:
 
     # Extract lists from settings
     restricted_packages = settings_dict.get("RESTRICTED_PACKAGES", [])
-    isolated_modules = settings_dict.get("ISOLATED_MODULES", [])
+    standalone_modules = settings_dict.get("STANDALONE_MODULES", [])
     std_lib_only = settings_dict.get("STD_LIB_ONLY", [])
     third_party_only = settings_dict.get("THIRD_PARTY_ONLY", [])
     first_party_only = settings_dict.get("FIRST_PARTY_ONLY", [])
@@ -43,10 +43,10 @@ def check_conflicts(settings_dict: dict) -> list | None:
             f"--std-lib-only and --third-party-only."
         )
 
-    # Check for intersections between isolated_modules and other list options
+    # Check for intersections between standalone_modules and other list options
     conflicts.extend(
-        f"Conflict: {set(isolated_modules).intersection(packages)}. "
-        f"Modules set to --isolated-modules cannot be included in {option}."
+        f"Conflict: {set(standalone_modules).intersection(packages)}. "
+        f"Modules set to --standalone-modules cannot be included in {option}."
         for option, packages in [
             ("--import-restrictions", list(import_restrictions.keys())),
             ("--restricted-packages", restricted_packages),
@@ -56,7 +56,7 @@ def check_conflicts(settings_dict: dict) -> list | None:
             ("--project-only", project_only),
             ("--base-package-only", base_package_only),
         ]
-        if set(isolated_modules).intersection(packages)
+        if set(standalone_modules).intersection(packages)
     )
 
     # If no conflicts are detected

--- a/src/flake8_custom_import_rules/utils/parse_utils.py
+++ b/src/flake8_custom_import_rules/utils/parse_utils.py
@@ -159,26 +159,26 @@ def does_file_match_custom_rule(file_identifier: str, custom_rules: list[str] | 
 
 
 def does_import_match_custom_import_restriction(
-    node_identifier: str, isolated_imports: list[str] | str | None
+    node_identifier: str, standalone_imports: list[str] | str | None
 ) -> bool:
     """
-    Check if an import identifier is in an isolated import.
+    Check if an import identifier is in a standalone import.
 
     Parameters
     ----------
     node_identifier : str
         The import identifier to check.
-    isolated_imports : list[str] | str | None
-        A list of isolated imports or a single isolated import to check against.
+    standalone_imports : list[str] | str | None
+        A list of standalone imports or a single standalone import to check against.
 
     Returns
     -------
     bool
     """
-    if isolated_imports is None:
+    if standalone_imports is None:
         return False
     restricted_imports = (
-        [isolated_imports] if isinstance(isolated_imports, str) else isolated_imports
+        [standalone_imports] if isinstance(standalone_imports, str) else standalone_imports
     )
     return check_string(node_identifier, prefix=tuple(restricted_imports), delimiter=" ")
 

--- a/tests/test_cases/custom_import_rules/standalone_modules_test.py
+++ b/tests/test_cases/custom_import_rules/standalone_modules_test.py
@@ -6,7 +6,7 @@
 - CIR304
 
 To run this test file only:
-poetry run python -m pytest -vvvrca tests/test_cases/custom_import_rules/isolated_modules_test.py
+poetry run python -m pytest -vvvrca tests/test_cases/custom_import_rules/standalone_modules_test.py
 """
 import pycodestyle
 import pytest
@@ -23,7 +23,7 @@ CIR303 = ErrorCode.CIR303.full_message
 CIR304 = ErrorCode.CIR304.full_message
 
 CUSTOM_MSG = (
-    ". Isolated module 'my_second_base_package.module_three' cannot import from project packages."
+    ". Standalone module 'my_second_base_package.module_three' cannot import from project packages."
 )
 
 MODULE_THREE_PACKAGE_ERRORS = {
@@ -43,7 +43,7 @@ MODULE_THREE_MODULE_ERRORS = {
 
 
 @pytest.mark.parametrize(
-    ("test_case", "isolated_modules_imports", "expected"),
+    ("test_case", "standalone_modules_imports", "expected"),
     [
         (
             "example_repos/my_base_module/my_second_base_package/module_three.py",
@@ -90,7 +90,7 @@ MODULE_THREE_MODULE_ERRORS = {
             ["my_second_base_package.module_two", "my_second_base_package.module_one"],
             {
                 f"10:0: {CIR302} Using 'from my_second_base_package.module_one."
-                f"file_two import ModuleTwo'. Isolated module "
+                f"file_two import ModuleTwo'. Standalone module "
                 f"'my_second_base_package.module_two.file_one' cannot import "
                 f"from project packages."
             },
@@ -100,24 +100,24 @@ MODULE_THREE_MODULE_ERRORS = {
             ["my_second_base_package.module_two.file_one", "my_second_base_package.module_one"],
             {
                 f"11:0: {CIR304} Using 'from my_second_base_package.module_two."
-                f"file_two import ModuleTwoFileTwo'. Isolated module "
+                f"file_two import ModuleTwoFileTwo'. Standalone module "
                 f"'my_second_base_package.module_two.file_one' cannot import "
                 f"from project packages.",
                 f"10:0: {CIR304} Using 'from my_second_base_package.module_one."
-                f"file_two import ModuleTwo'. Isolated module "
+                f"file_two import ModuleTwo'. Standalone module "
                 f"'my_second_base_package.module_two.file_one' cannot import "
                 f"from project packages.",
             },
         ),
     ],
 )
-def test_isolated_modules_imports(
+def test_standalone_modules_imports(
     test_case: str,
-    isolated_modules_imports: list[str],
+    standalone_modules_imports: list[str],
     expected: set,
     get_flake8_linter_results: callable,
 ) -> None:
-    """Test isolated_modules imports."""
+    """Test standalone_modules imports."""
     filename = normalize_path(test_case)
     lines = pycodestyle.readlines(filename)
     identifier = get_module_name_from_filename(filename)
@@ -126,7 +126,7 @@ def test_isolated_modules_imports(
         "base_packages": ["my_second_base_package", "my_base_module"],
         "checker_settings": Settings(
             **{
-                "ISOLATED_MODULES": isolated_modules_imports,
+                "STANDALONE_MODULES": standalone_modules_imports,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
                 "RESTRICT_LOCAL_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
@@ -139,12 +139,12 @@ def test_isolated_modules_imports(
     assert actual == expected, sorted(actual)
 
 
-def test_isolated_modules_import_settings_do_not_error(
+def test_standalone_modules_import_settings_do_not_error(
     valid_custom_import_rules_imports: str,
     get_flake8_linter_results: callable,
 ) -> None:
-    """Test isolated_modules imports do not have an effect on regular import methods."""
-    options = {"checker_settings": Settings(**{"ISOLATED_MODULES": []})}
+    """Test standalone_modules imports do not have an effect on regular import methods."""
+    options = {"checker_settings": Settings(**{"STANDALONE_MODULES": []})}
     actual = get_flake8_linter_results(
         s=valid_custom_import_rules_imports, options=options, delimiter="\n"
     )

--- a/tests/utils/option_utils_test.py
+++ b/tests/utils/option_utils_test.py
@@ -8,7 +8,7 @@ def test_check_conflicts():
     sample_settings = Settings()
     sample_settings.THIRD_PARTY_ONLY = ["package1", "package2"]
     sample_settings.FIRST_PARTY_ONLY = ["package2", "package3"]
-    sample_settings.ISOLATED_MODULES = ["module1"]
+    sample_settings.STANDALONE_MODULES = ["module1"]
     sample_settings.IMPORT_RESTRICTIONS = {
         "module1": ["submoduleA", "submoduleB"],
         "module2": ["submoduleC"],

--- a/tests/utils/parse_utils_test.py
+++ b/tests/utils/parse_utils_test.py
@@ -133,7 +133,7 @@ PACKAGE_6 = [
 
 
 @pytest.mark.parametrize(
-    ("node_identifier", "isolated_imports", "expected"),
+    ("node_identifier", "standalone_imports", "expected"),
     [
         ("my_second_base_package.module_one.file_one", PACKAGE_6, True),
         ("my_second_base_package.module_one.file_two", PACKAGE_6, True),
@@ -147,12 +147,12 @@ PACKAGE_6 = [
     ],
 )
 def test_does_import_match_custom_import_restriction(
-    node_identifier: str, isolated_imports: list[str], expected: bool
+    node_identifier: str, standalone_imports: list[str], expected: bool
 ) -> None:
     """Test does_import_match_custom_import_restriction."""
     assert (
         does_import_match_custom_import_restriction(
-            node_identifier=node_identifier, isolated_imports=isolated_imports
+            node_identifier=node_identifier, standalone_imports=standalone_imports
         )
         == expected
     )


### PR DESCRIPTION
…andalone modules to better reflect and describe what the flag does

Standalone Modules
~~~~~~~~~~~~~~~~~~

The `--standalone-modules` flag allows you to define a list of packages that cannot import from any other packages within your base package. This ensures that certain packages remain standalone and do not introduce unwanted dependencies.

For instance, you might have a 'standalone_package' that performs a specific task independently. To ensure it remains decoupled from the rest of the application, you can make this package standalone.

## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
