### PR TITLE
refactor(local-imports): Use local scope imports for clarity instead

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,9 @@ indent_style = tab
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = 4
+
+[*.py]
 
 [*.{yaml,yml}]
 indent_size = 2

--- a/README.rst
+++ b/README.rst
@@ -121,46 +121,46 @@ of imports:
 =======================  =====================================================
  Custom Import Rules        Description
 =======================  =====================================================
-project_only                This flag enforces that only project-level
+project-only                This flag enforces that only project-level
                             modules can be imported. This can be used
                             in a project where third-party dependencies
                             are intended to be minimized, and most of
                             the functionality is implemented within the
                             project itself.
 
-base_package_only           This flag enforces that only the base package
+base-package-only           This flag enforces that only the base package
                             of the project can be imported. This can be
                             used in a project with a specific structure
                             where all functionality is accessed through
                             the base package.
 
-first_party_only            This flag enforces that only first-party
+first-party-only            This flag enforces that only first-party
                             modules (i.e., those developed as part of
                             the project) can be imported. This could
                             be used in a project where third-party
                             dependencies are intended to be minimized.
 
-standalone_modules          This flag enforces that only modules that
+standalone-modules          This flag enforces that only modules that
                             are marked as 'standalone' can be imported.
                             This could be used in a project where
                             certain modules are intended to be used
                             independently of the rest of the project.
 
-std_lib_only                This flag enforces that only standard
+std-lib-only                This flag enforces that only standard
                             library modules can be imported. This
                             could be used in a project where it is
                             intended to rely solely on the standard
                             library, without any third-party
                             dependencies.
 
-third_party_only            This flag enforces that only third-party
+third-party-only            This flag enforces that only third-party
                             modules can be imported. This could be
                             used in a project where it is intended
                             to rely heavily on third-party libraries,
                             and not on the standard library or
                             project-specific modules.
 
-restricted_packages         This flag enforces that certain specified
+restricted-packages         This flag enforces that certain specified
                             packages cannot be imported. This could be
                             used in a project where certain packages
                             are known to cause issues or are not
@@ -338,7 +338,7 @@ There are also several flags available to restrict specific
 types of imports. These include:
 
 * `--restrict-relative-imports`
-* `--restrict-local-imports`
+* `--restrict-local-scope-imports`
 * `--restrict-conditional-imports`
 * `--restrict-dynamic-imports`
 * `--restrict-private-imports`
@@ -361,10 +361,13 @@ restrict-relative-imports       This flag prevents the usage of relative imports
                                 sometimes lead to confusion or unintended behavior,
                                 especially in larger code bases. On by default.
 
-restrict-local-imports          This flag restricts the import of modules that are
-                                local to the project. This could be useful to enforce
-                                dependencies only on external libraries and not on
-                                project-specific modules.
+restrict-local-scope-imports    This flag restricts local scope imports, preventing
+                                the import of modules or specific functions within
+                                a particular scope, such as inside a function or
+                                method. It enforces that all imports occur at the
+                                top-level of the file, promoting code clarity and
+                                consistency.
+
 
 restrict-conditional-imports    This flag restricts the use of conditional imports.
                                 Conditional imports are imports that occur within an
@@ -453,10 +456,10 @@ these flags can be enabled or disabled independently,
 allowing for fine-grained control over your project's import
 structure.
 
-Top-level Only Imports
-~~~~~~~~~~~~~~~~~~~~~~
+Restrict Relative Imports
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `--top-level-only-imports` flag is currently not implemented.
+The `--restrict-relative-imports` flag is currently not implemented.
 Once available, it should allow you to restrict certain packages
 or modules to only import from the top-level package.
 
@@ -471,6 +474,13 @@ you can set:
 
 With this setting, any relative imports in your project will be
 flagged by the linter.
+
+Top-level Only Imports
+~~~~~~~~~~~~~~~~~~~~~~
+
+The `--top-level-only-imports` flag is currently not implemented.
+Once available, it should allow you to restrict certain packages
+or modules to only import from the top-level package.
 
 These rules and flags allow you to enforce a clean and
 understandable structure for your project's imports, making
@@ -694,9 +704,9 @@ your config file can be named in either of two ways:
                         detected. This occurs when the
                         **--restrict-relative-imports** option is enabled.
 
-  **PIR103**            This error is thrown when a local import is
+  **PIR103**            This error is thrown when a local scope import is
                         detected. This occurs when the
-                        **--restrict-local-imports** option is enabled.
+                        **--restrict-local-scope-imports** option is enabled.
 
   **PIR104**            This error is thrown when a conditional import is
                         detected. This occurs when the

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,34 +1,727 @@
-# Glossary
+# Glossary and Terminology
+
 Welcome to the "Glossary," a comprehensive guide to
 understanding key concepts and terminology in the
 `flake8-custom-import-rules` package.
 
-### Python Modules
-Definition: A module is a single file containing Python
+## Aliased Imports
+
+Aliased imports in Python refer to the practice of
+importing a module or specific symbols from a module
+under a different name, typically to make the code
+more concise or to avoid naming conflicts. This is
+done using the `as` keyword, allowing you to assign a
+different name (alias) to the imported module or
+symbol.
+
+Here's an example of an aliased import:
+
+```python
+import numpy as np
+```
+
+In this example, the numpy module is imported under
+the alias np, so you can refer to it as np in your
+code instead of numpy. This is a common convention in
+the scientific and data analysis community.
+
+Here's another example, where a specific symbol is
+aliased:
+
+```python
+from matplotlib import pyplot as plt
+```
+
+Here, the `pyplot` module from the `matplotlib` package
+is imported under the alias `plt`.
+
+### Advantages of Aliased Imports:
+
+1.  **Conciseness**: Aliasing can make the code more
+    concise, especially when dealing with modules or
+    symbols with long or cumbersome names.
+
+2.  **Avoiding Naming Conflicts**: If you have symbols
+    with the same name in different modules, you can use
+    aliasing to avoid conflicts.
+
+3.  **Community Conventions**: Certain aliases are widely
+    recognized and used in specific communities, such as
+    `np` for `numpy` or `pd` for `pandas`.
+
+### Disadvantages and Considerations:
+
+1.  **Potential Confusion**: Non-standard or
+    unconventional aliases might lead to confusion,
+    especially for readers who are not familiar with the
+    specific aliasing choices.
+2.  **Loss of Clarity**: Overuse of aliasing or using
+    overly short or cryptic aliases can reduce the
+    readability of the code.
+
+### Best Practices and Recommendations:
+
+-   **Use Standard Aliases**: Where possible, stick to
+    widely recognized and accepted aliases, such as `np`
+    for `numpy`.
+-   **Be Clear and Consistent**: If you choose to use
+    aliases, make sure they are clear, descriptive, and
+    used consistently throughout your codebase.
+-   **Consider Readability**: Use aliasing judiciously and
+    consider the trade-off between conciseness and
+    readability.
+
+In summary, aliased imports are a useful tool in Python,
+allowing for more concise code and the ability to handle
+naming conflicts. However, they should be used
+thoughtfully and in line with community standards and best
+practices to maintain code clarity and readability.
+
+## Conditional Imports
+
+Conditional imports in Python refer to the practice of
+importing a module or specific symbols from a module based
+on certain conditions or runtime logic. This means that the
+import statement is executed only if a particular condition
+is met, typically determined by an `if` statement or
+similar control structure.
+
+Here's an example that illustrates the concept of
+conditional imports:
+
+```python
+import sys
+
+if sys.version_info[0] == 3:
+    import urllib.request as urllib_request
+else:
+    import urllib2 as urllib_request
+```
+
+In this example, the code checks the major version of
+Python being used and imports the appropriate module
+accordingly. This can be useful for maintaining
+compatibility across different versions of Python or
+other varying environments.
+
+### Advantages of Conditional Imports:
+
+1.  **Compatibility**: As shown above, conditional
+    imports can be used to handle differences between
+    Python versions, platforms, or other varying
+    environments, helping to maintain compatibility.
+2.  **Optimization**: By importing modules only when
+    necessary, you might optimize the loading time or
+    resource utilization of your program, especially when
+    dealing with large or resource-heavy modules.
+
+### Disadvantages and Risks of Conditional Imports:
+
+1.  **Code Complexity**: Conditional imports can increase
+    the complexity of the code, making it harder to read,
+    understand, and maintain.
+2.  **Potential Inconsistency**: The behavior of the code
+    might become inconsistent or harder to predict, as the
+    availability of a module or specific symbols may
+    depend on runtime conditions.
+
+### Best Practices and Recommendations:
+
+-   **Clear Documentation**: If you use conditional
+    imports, make sure to document the conditions and the
+    reasoning behind them to help others (and yourself)
+    understand the code.
+-   **Testing**: Thoroughly test the code under different
+    conditions to ensure that the conditional imports work
+    as intended and do not introduce unexpected behavior or
+    bugs.
+-   **Avoid Overuse**: Consider whether conditional
+    imports are truly necessary for your use case, and
+    avoid overusing them, as they can lead to more complex
+    and challenging-to-maintain code.
+
+Conditional imports are a tool best suited for specific
+scenarios, such as handling differences between Python
+versions or platforms. In general code, it's usually
+preferable to stick with straightforward and consistent
+import statements.
+
+
+## Dynamic Imports
+
+Dynamic imports in Python refer to the practice of
+importing modules or specific symbols from modules at
+runtime, based on conditions or logic within the code.
+Unlike standard imports, which are resolved at the time the
+code is compiled, dynamic imports are resolved when the
+code is executed. This is achieved using functions like
+`importlib.import_module` or the built-in `__import__`
+function.
+
+Here's an example that illustrates the concept of dynamic
+imports:
+
+```python
+import importlib
+
+module_name = "os" if some_condition else "sys"
+module = importlib.import_module(module_name)
+```
+
+In this example, the code dynamically imports either the
+`os` or `sys` module, depending on the value of `some_condition`.
+
+### Advantages of Dynamic Imports:
+
+1.  **Flexibility**: Dynamic imports allow you to load modules
+    based on runtime conditions, giving you more control and
+    adaptability in your code.
+
+2.  **Optimization**: By importing modules only when needed, you
+    can potentially reduce the initial loading time or resource
+    utilization of your application.
+
+### Disadvantages and Risks of Dynamic Imports:
+
+1.  **Code Complexity**: Dynamic imports can add complexity to
+    the code, making it more challenging to read, understand, and
+    maintain.
+
+2.  **Potential Errors**: Errors related to dynamic imports might
+    only manifest at runtime, making them harder to catch and
+    debug.
+
+### Best Practices and Recommendations:
+
+-   **Use Standard Libraries**: Utilize the `importlib` standard
+    library for dynamic imports rather than relying on the
+    lower-level `__import__` function.
+
+-   **Testing**: Ensure thorough testing of the code paths that
+    involve dynamic imports to catch potential issues.
+
+-   **Documentation**: Clearly document the reasoning and usage of
+    dynamic imports in the code to aid understanding.
+
+### Limitations and Considerations:
+
+-   **Static Analysis Limitations**: Tools that perform static
+    analysis on the code might have difficulty handling dynamic
+    imports, as the imported modules are determined at runtime.
+
+In summary, dynamic imports are a powerful but complex feature in
+Python, allowing for more adaptable and potentially optimized
+code. Care must be taken in their use to ensure clarity,
+maintainability, and robustness.
+
+## Future Imports ( \_\_future__ )
+
+Future imports in Python are a special mechanism that
+allows you to enable features that will become standard in
+future versions of the language. By using future imports,
+you can ensure compatibility with newer Python versions
+and make your code more forward-compatible.
+
+The `__future__` module in Python provides these future
+import statements. When you import a feature from
+`__future__`, it changes the compiler's behavior to
+include that feature, even if it's not the default
+behavior in the current version of Python.
+
+
+Here's an example of a future import:
+
+```python
+from __future__ import division
+```
+
+This import changes the division operator `/` to always
+perform true division, returning a floating-point result
+even when dividing two integers. This behavior became the
+default in Python 3, but the above import allows you to
+use it in Python 2 as well.
+
+### Common Uses of Future Imports:
+
+1.  **Division Behavior**: As shown above, changing the
+    behavior of the division operator to be consistent
+    with Python 3.
+
+2.  **Print Function**: Enabling the use of the `print`
+    function instead of the `print` statement in Python 2,
+    making the code compatible with Python 3.
+
+3.  **Unicode Literals**: Enabling the use of Unicode
+    literals in Python 2, consistent with the behavior in
+    Python 3.
+
+### Advantages of Future Imports:
+
+1.  **Forward Compatibility**: Future imports help prepare
+    your code for future versions of Python, making the
+    transition smoother when you decide to upgrade.
+
+2.  **Consistency**: If you're working in an environment
+    with different versions of Python, future imports can
+    help ensure consistent behavior across those versions.
+
+### Considerations and Best Practices:
+
+1.  **Explicitness**: Future imports should be used
+    explicitly in each module where the future behavior is
+    needed.
+
+2.  **Placement**: Future imports must appear at the top
+    of the file, before any other imports or code, to affect
+    the entire module.
+
+3.  **Documentation**: If you're using future imports, it
+    may be helpful to document why, especially if the reason
+    might not be immediately obvious to others reading the
+    code.
+
+In summary, future imports are a valuable tool for ensuring
+forward compatibility and consistency across different Python
+versions. By understanding and using them appropriately, you
+can write code that's more robust and maintainable as the
+Python language evolves.
+
+
+## Importing a Package Locally
+
+This typically refers to importing a package that resides
+within the local file system or project directory. It may
+be a package or module developed specifically for the
+project or a third-party package that has been downloaded
+and stored locally. It's accessed directly from the local
+path rather than from a globally installed location or
+package repository.
+
+Example:
+```python
+import my_local_package
+from .local_module import local_function
+```
+
+In this context, "local" refers to the physical location of
+the package on the system.
+
+While the terms local scope import and import a package locally
+may sound similar, they refer to different
+aspects of the import process. The first is concerned with
+where the package or module is located on the file system,
+while the second deals with where in the code the import
+statement is placed and the scope of the imported elements.
+
+
+## Local Scope Import
+A local import often refers to an import statement that
+is specific to a particular scope within the code. It
+may mean importing a module or function within a specific
+function or method, rather than at the top level of a
+file. This type of import is often used to minimize
+the scope of the imported element, ensuring that it's
+only available where it's needed.
+
+**Example:**
+
+```python
+def my_function():
+    """A function that imports a module locally."""
+    import requests  # third-party local import
+    response = requests.get('https://example.com')
+    return response.text
+```
+
+Here, "local" refers to the scope and context of the
+import, not the physical location of the imported module.
+
+
+### **Advantages of Local Scope Imports:**
+
+1.  **Reduced Initial Loading Time**: If a module is
+    imported inside a function and that function is never
+    called, the module won't be imported, potentially
+    reducing the initial loading time of the script.
+
+2.  **Avoiding Circular Dependencies**: Sometimes, local
+    imports can help in avoiding circular dependencies
+    between different modules.
+
+3.  **Selective Importing**: Importing only in the scope
+   where it is needed can help in keeping the global
+   namespace clean.
+
+### **Disadvantages of Local Scope Imports:**
+
+1.  **Potential Performance Overhead**: If a function with a
+    local import is called many times, the import statement
+    will be executed each time the function is called,
+    which might introduce a small performance overhead.
+
+2.  **Code Clarity**: Local imports can make the code harder
+    to follow, especially if overused, as it may become
+    unclear where exactly different modules and functions
+    are being imported.
+
+### **When to Use Local Scope Imports:**
+
+Local scope imports are not common in every project, and
+their usage often depends on specific needs, coding
+guidelines, and design considerations. They might be used
+to solve particular problems like circular dependencies
+or to optimize the loading of large and infrequently used
+modules.
+
+Typically, code style guides recommend importing at the
+top level of the file for clarity and consistency, but
+local scope imports can be a valuable tool in certain
+situations.
+
+
+## Main Script Imports (\_\_main__)
+
+Importing from the `__main__` module or a `__main__.py`
+file is generally not considered best practice in Python
+development.
+
+### Importing from the `__main__` Module
+
+The `__main__` module is the entry point of a program, and
+it's the context in which the top-level script is run.
+Importing from this module is relatively uncommon and can
+lead to code that is difficult to understand or maintain.
+Here are some reasons why:
+
+-   **Uncommon Practice**: The `__main__` module is
+    typically associated with script execution, not with
+    defining reusable components.
+
+-   **Potential Confusion**: It might be unclear what is
+    being imported from `__main__`, especially if the main
+    script is large or complex.
+
+-   **Code Organization Issues**: Needing to import from
+    `__main__` may indicate that the code could benefit
+    from reorganization.
+
+-   **Testing Challenges**: Code that relies on imports
+    from `__main__` may be more difficult to test in
+    isolation.
+
+### Importing from a `__main__.py` File
+
+The `__main__.py` file is used to define the entry point
+for a package when it's executed as a script. Here's why
+importing from `__main__.py` can be problematic:
+
+-   **Lack of Clarity**: Like the `__main__` module,
+    `__main__.py` is usually associated with script
+    execution, not with defining reusable components.
+
+-   **Potential Circular Dependencies**: You can easily end
+    up with circular dependencies that are difficult to
+    resolve.
+
+-   **Maintenance Challenges**: Serving dual purposes can
+    become a maintenance burden.
+
+-   **Incompatibility with Certain Tools**: Some tools
+    might treat `__main__.py` specially, leading to
+    unexpected behavior.
+
+### Recommended Structure
+
+Instead of putting reusable code in the `__main__` module
+or `__main__.py` file, it's generally a better practice to
+define functions, classes, and other reusable components in
+separate modules within your package. Here's an example
+structure:
+
+```plaintext
+mypackage/
+├── __main__.py         # Entry point for script execution
+├── utilities.py        # Reusable functions and classes
+└── other_module.py     # Other reusable components
+```
+In `__main__.py`, you can import from `utilities.py` and
+other_module.py as needed for script execution. This keeps
+your codebase organized and clear and avoids the potential
+problems mentioned above.
+
+In summary, while importing from the `__main__` module or a
+`__main__.py` file is technically possible, it's generally
+not a common or recommended practice. Organizing code into
+separate modules enhances clarity, maintainability, and
+avoids potential issues.
+
+
+## Private Imports
+
+Private imports in Python refer to the practice of
+importing symbols (such as functions, classes, or variables)
+that are intended for internal use within a module or
+package and are not part of the public API. These symbols
+are often prefixed with an underscore (`_`), which by
+convention signals that they are considered "private" or
+"internal" and should not be accessed directly by external
+code.
+
+Here's an example to illustrate private imports:
+
+Suppose you have a module `my_module.py`:
+
+```python
+# my_module.py
+
+def public_function():
+    """A public function that can be accessed externally."""
+    return _private_helper_function()
+
+def _private_helper_function():
+    return "This is a private function!"
+```
+
+You might import and use the `_private_helper_function` within
+the same package, but it is not intended to be accessed
+directly by external code.
+
+### Why Use Private Imports?
+
+1.  **Encapsulation**: By marking certain symbols as private,
+    you can define a clear and stable public API while keeping
+    the flexibility to change, remove, or refactor the internal
+    implementation without affecting external code.
+
+2.  **Code Organization**: Private imports help organize code by
+    clearly separating the public interface from the internal
+    implementation details.
+
+### Best Practices and Recommendations:
+
+-   **Naming Convention**: Use a single leading underscore to
+    mark symbols as private. This does not prevent access to the
+    symbols but serves as a gentle warning to other developers
+    that the symbol is considered internal.
+
+-   **Documentation**: Clearly document which parts of your module
+    or package are considered public and which are private.
+
+-   **Respect the Convention**: As a consumer of other modules or
+    packages, respect the private nature of symbols with leading
+    underscores and avoid using them directly.
+
+### Limitations and Considerations:
+
+-   **No Strict Enforcement**: Python does not provide a strict
+    mechanism to enforce private access. The leading underscore is
+    a convention, not a hard restriction, so external code can still
+    import and use private symbols. However, doing so is generally
+    considered bad practice and may lead to compatibility issues if
+    the internal symbols change in future versions of the module
+    or package.
+
+-   **Not to be Confused with Name Mangling**: Double leading
+    underscores (e.g., `__private_var`) trigger name mangling in
+    Python, which alters the name to avoid clashes in subclasses.
+    This is a separate mechanism and not the same as marking a
+    symbol as private.
+
+In summary, private imports are a valuable tool in designing
+clean and maintainable code by defining a clear boundary between
+public interfaces and internal implementation. They rely on
+community conventions and developer discipline rather than strict
+language enforcement.
+
+
+
+## Python Modules
+
+**Definition**: A module is a single file containing Python
 code. It can contain functions, variables, classes, and
 runnable code. Essentially, any Python file with a `.py`
 extension is a module.
 
-Purpose: Modules are used to organize code into reusable
+**Purpose**: Modules are used to organize code into reusable
 and manageable chunks. By putting related functions and
 variables into a module, you can import them into other
 Python files.
 
-Example: A file named `mymodule.py` containing functions
+**Example:**
+
+A file named `mymodule.py` containing functions
 and classes related to mathematical operations.
 
-### Python Packages
-Definition: A package is a directory that contains
+## Python Packages
+
+**Definition**: A package is a directory that contains
 multiple module files and a special `__init__.py` file.
 The presence of `__init__.py` (which can be empty) tells
 Python that the directory should be considered a package.
 
-Purpose: Packages are used to organize multiple modules
+**Purpose**: Packages are used to organize multiple modules
 into a hierarchical namespace. This allows for structuring
 your code in a way that groups related modules together,
 making it more maintainable and scalable.
 
-Example: A directory named mypackage containing several
+**Example:**
+
+A directory named mypackage containing several
 module files related to different aspects of data
 processing, and an `__init__.py` file to signify it as a
 package.
+
+## Relative Imports
+
+Relative imports in Python allow you to import modules or
+specific objects from modules that are located relative to
+the current module or package. They make use of dots (`.`)
+to indicate the relative path to the desired module within
+the same package hierarchy.
+
+Here's a breakdown of how relative imports work:
+
+-   A single dot (`.`) refers to the current package or
+    directory.
+-   Two dots (`..`) refer to the parent package or
+    directory.
+-   Additional dots (`...`, `....`, etc.) refer to
+    higher-level parent packages or directories.
+
+**Example:**
+
+Consider the following directory structure:
+
+```plaintext
+my_package/
+├── subpackage_a/
+│   ├── module_a.py
+│   └── __init__.py
+├── subpackage_b/
+│   ├── module_b.py
+│   └── __init__.py
+└── __init__.py
+```
+
+If you want to import `module_a.py` from `module_b.py`,
+you can use a relative import like this (inside
+`module_b.py`):
+
+```python
+from ..subpackage_a import module_a
+```
+
+### **Advantages of Relative Imports**
+
+1.  **Portability**: Relative imports make the code more
+   portable, as they don't rely on the absolute path of
+   the module. If you move the package to a different
+   location, the relative imports will still work.
+
+2.  **Readability**: In a well-structured project, relative
+   imports can make the code more concise and clear by
+   showing the relationship between modules.
+
+### **Potential Issues**
+
+1.  **Ambiguity**: Without clear context, relative imports
+   might be less intuitive to understand, especially in a
+   complex project.
+
+2.  **Compatibility**: Relative imports require the file to
+   be part of a package (i.e., there must be an
+   `__init__.py` file), and they are not meant to be used
+   in standalone scripts.
+
+### **Best Practices**
+
+While relative imports can be useful, it's essential to
+use them thoughtfully and consistently. Many projects
+prefer to use absolute imports for clarity, especially if
+the package structure is not overly complex. Mixing
+relative and absolute imports without clear guidelines can
+lead to confusing code.
+
+In Python 3, all imports that start with a dot are
+considered relative, and attempting to perform a relative
+import from a script that is not part of a package will
+result in an ImportError. Therefore, understanding the
+package structure and following consistent practices is key
+to using relative imports effectively.
+
+
+## Wildcard Imports
+
+Wildcard imports in Python refer to the practice of
+importing all symbols (functions, classes, variables, etc.)
+from a module into the current namespace using the asterisk
+(`*`) symbol. This can make all the names defined in the
+imported module available in the current scope without
+needing to prefix them with the module name.
+
+Here's an example of a wildcard import:
+
+```python
+from math import *
+```
+
+After this import, you can directly use functions like
+`sqrt`, `sin`, `cos`, etc., from the `math` module
+without prefixing them with `math.`.
+
+### **Advantages of Wildcard Imports**
+
+1.  **Conciseness**: Wildcard imports can make the code
+   more concise, as you don't need to prefix every call
+   with the module name or list all the specific names
+   you want to import.
+
+### **Disadvantages and Risks of Wildcard Imports**
+
+1.  **Namespace Clashes**: If different modules define
+   symbols with the same name, wildcard imports can lead
+   to name clashes, potentially overwriting existing names
+   in the current namespace.
+
+2.  **Readability and Maintainability**: Wildcard imports
+   can make the code less readable, as it becomes unclear
+   where a specific symbol comes from. This can make code
+   maintenance and debugging more challenging.
+
+3.  **Lack of Control**: By importing everything, you may
+   bring into scope symbols that you don't need or intend
+   to use, cluttering the namespace.
+
+4.  **Potential Inefficiency**: Importing everything from
+   a large module might consume more memory or slow down
+   the loading time, even if you only need a small subset
+   of the functions or classes.
+
+### **Best Practices and Recommendations**
+
+Wildcard imports are generally discouraged in production
+code due to the risks and disadvantages mentioned above.
+Many style guides, such as PEP 8, recommend avoiding
+wildcard imports and instead explicitly listing the names
+you want to import. This promotes clarity, maintainability,
+and reduces the risk of unexpected behavior.
+
+If you need to use many symbols from a module, you can
+import the module itself and then use the module prefix to
+access its symbols:
+
+```python
+import math
+
+result = math.sqrt(16)
+```
+
+Or, you can explicitly list the symbols you want to
+import:
+
+```python
+from math import sqrt, sin, cos
+```
+
+Both of these approaches provide more control and clarity
+compared to wildcard imports.

--- a/src/flake8_custom_import_rules/core/import_rules.py
+++ b/src/flake8_custom_import_rules/core/import_rules.py
@@ -366,7 +366,7 @@ class CustomImportRules:
                 self._check_for_pir102,
             ),
             (
-                self.checker_settings.RESTRICT_LOCAL_IMPORTS,
+                self.checker_settings.RESTRICT_LOCAL_SCOPE_IMPORTS,
                 [ParsedLocalImport],
                 self._check_for_pir103,
             ),

--- a/src/flake8_custom_import_rules/defaults.py
+++ b/src/flake8_custom_import_rules/defaults.py
@@ -33,7 +33,7 @@ STDIN_IDENTIFIERS = {"stdin", "-", "/dev/stdin", "", None}
 
 STANDARD_PROJECT_LEVEL_RESTRICTION_KEYS = [
     "RESTRICT_RELATIVE_IMPORTS",
-    "RESTRICT_LOCAL_IMPORTS",
+    "RESTRICT_LOCAL_SCOPE_IMPORTS",
     "RESTRICT_CONDITIONAL_IMPORTS",
     "RESTRICT_DYNAMIC_IMPORTS",
     "RESTRICT_PRIVATE_IMPORTS",
@@ -120,7 +120,7 @@ class Settings:
     # Set Defaults for Project Import Restrictions
     TOP_LEVEL_ONLY_IMPORTS: bool = True
     RESTRICT_RELATIVE_IMPORTS: bool = True
-    RESTRICT_LOCAL_IMPORTS: bool = True
+    RESTRICT_LOCAL_SCOPE_IMPORTS: bool = True
     RESTRICT_CONDITIONAL_IMPORTS: bool = False
     RESTRICT_DYNAMIC_IMPORTS: bool = True
     RESTRICT_PRIVATE_IMPORTS: bool = True
@@ -221,7 +221,7 @@ HELP_STRINGS = {
     # permitted in the project. (default: True)
     # "restrict-relative-imports": If set to True, relative imports for the
     # project are disabled. (default: True)
-    # restrict-local-imports RESTRICT_LOCAL_IMPORTS: If set to True, local
+    # restrict-local-scope-imports RESTRICT_LOCAL_SCOPE_IMPORTS: If set to True, local
     # imports for the project are disabled. (default: True)
     # restrict-conditional-imports RESTRICT_CONDITIONAL_IMPORTS: If set to
     # True, conditional imports for the project are disabled. (default: False)
@@ -257,7 +257,7 @@ ERROR_CODES = {
     "standalone-modules": "CIR301 to CIR304",
     "top-level-only-imports": "PIR101",
     "restrict-relative-imports": "PIR102",
-    "restrict-local-imports": "PIR103",
+    "restrict-local-scope-imports": "PIR103",
     "restrict-conditional-imports": "PIR104",
     "restrict-dynamic-imports": "PIR105",
     "restrict-private-imports": "PIR106",

--- a/src/flake8_custom_import_rules/utils/node_utils.py
+++ b/src/flake8_custom_import_rules/utils/node_utils.py
@@ -8,16 +8,18 @@ from flake8_custom_import_rules.utils.parse_utils import parse_module_string
 
 def get_package_names(module_name: str) -> list[str] | None:
     """
-    Return a list of package names for a module name.
+    Get the package names for a given module.
 
     Parameters
     ----------
     module_name : str
-        The module name.
+        The name of the module.
 
     Returns
     -------
     list[str] | None
+        A list of package names for the module. Returns None
+        if no package names are found.
     """
     tree = ast.parse(module_name)
 

--- a/tests/test_cases/custom_import_rules/base_package_test.py
+++ b/tests/test_cases/custom_import_rules/base_package_test.py
@@ -60,7 +60,7 @@ def test_base_package_only_imports(
             **{
                 "BASE_PACKAGE_ONLY": base_package_only_imports,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),

--- a/tests/test_cases/custom_import_rules/first_party_only_test.py
+++ b/tests/test_cases/custom_import_rules/first_party_only_test.py
@@ -60,7 +60,7 @@ def test_first_party_only_imports(
                 # "PROJECT_ONLY": first_party_only_imports,
                 # "BASE_PACKAGE_ONLY": first_party_only_imports,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),

--- a/tests/test_cases/custom_import_rules/import_restrictions_test.py
+++ b/tests/test_cases/custom_import_rules/import_restrictions_test.py
@@ -738,7 +738,7 @@ def test_complex_imports(
             **{
                 "IMPORT_RESTRICTIONS": convert_to_dict(package_10),
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),
@@ -870,7 +870,7 @@ def test_import_restrictions(
             **{
                 "IMPORT_RESTRICTIONS": convert_to_dict(package_10),
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),

--- a/tests/test_cases/custom_import_rules/project_only_test.py
+++ b/tests/test_cases/custom_import_rules/project_only_test.py
@@ -56,7 +56,7 @@ def test_project_only_imports(
             **{
                 "PROJECT_ONLY": project_only_imports,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),

--- a/tests/test_cases/custom_import_rules/restricted_package_test.py
+++ b/tests/test_cases/custom_import_rules/restricted_package_test.py
@@ -106,7 +106,7 @@ def test_complex_imports(
             **{
                 "RESTRICTED_PACKAGES": restricted_packages,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),
@@ -284,7 +284,7 @@ def test_restricted_packages(
             **{
                 "RESTRICTED_PACKAGES": restricted_packages,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),

--- a/tests/test_cases/custom_import_rules/standalone_modules_test.py
+++ b/tests/test_cases/custom_import_rules/standalone_modules_test.py
@@ -128,7 +128,7 @@ def test_standalone_modules_imports(
             **{
                 "STANDALONE_MODULES": standalone_modules_imports,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),

--- a/tests/test_cases/custom_import_rules/std_lib_only_test.py
+++ b/tests/test_cases/custom_import_rules/std_lib_only_test.py
@@ -73,7 +73,7 @@ def test_std_lib_only_imports(
             **{
                 "STD_LIB_ONLY": std_lib_only_imports,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),

--- a/tests/test_cases/custom_import_rules/third_party_only_test.py
+++ b/tests/test_cases/custom_import_rules/third_party_only_test.py
@@ -75,7 +75,7 @@ def test_third_party_only_imports(
             **{
                 "THIRD_PARTY_ONLY": third_party_only_imports,
                 "RESTRICT_DYNAMIC_IMPORTS": False,
-                "RESTRICT_LOCAL_IMPORTS": False,
+                "RESTRICT_LOCAL_SCOPE_IMPORTS": False,
                 "RESTRICT_RELATIVE_IMPORTS": False,
             }
         ),

--- a/tests/test_cases/project_import_rules/local_scope_import_test.py
+++ b/tests/test_cases/project_import_rules/local_scope_import_test.py
@@ -3,7 +3,7 @@
 PIR103 = "PIR103 Local imports are disabled for this project."
 
 To run this test file only:
-poetry run python -m pytest -vvvrca tests/test_cases/project_import_rules/local_import_test.py
+poetry run python -m pytest -vvvrca tests/test_cases/project_import_rules/local_scope_import_test.py
 """
 from textwrap import dedent
 
@@ -11,7 +11,7 @@ import pytest
 
 from flake8_custom_import_rules.defaults import Settings
 
-LOCAL_IMPORT_CODE = dedent(
+LOCAL_SCOPE_IMPORT_CODE = dedent(
     """
     import os
 
@@ -28,10 +28,10 @@ LOCAL_IMPORT_CODE = dedent(
 
 
 @pytest.mark.parametrize(
-    ("test_case", "expected", "restrict_local_imports"),
+    ("test_case", "expected", "restrict_local_scope_imports"),
     [
         (
-            LOCAL_IMPORT_CODE,
+            LOCAL_SCOPE_IMPORT_CODE,
             {
                 "5:4: PIR103 Local imports are disabled for this project.",
                 "8:4: PIR103 Local imports are disabled for this project.",
@@ -40,29 +40,40 @@ LOCAL_IMPORT_CODE = dedent(
             True,
         ),
         (
-            LOCAL_IMPORT_CODE,
+            LOCAL_SCOPE_IMPORT_CODE,
             set(),
             False,
         ),
     ],
 )
-def test_local_imports(
-    test_case: str, expected: set, restrict_local_imports: bool, get_flake8_linter_results: callable
+def test_local_scope_imports(
+    test_case: str,
+    expected: set,
+    restrict_local_scope_imports: bool,
+    get_flake8_linter_results: callable,
 ) -> None:
     """Test local imports."""
-    options = {"checker_settings": Settings(**{"RESTRICT_LOCAL_IMPORTS": restrict_local_imports})}
+    options = {
+        "checker_settings": Settings(
+            **{"RESTRICT_LOCAL_SCOPE_IMPORTS": restrict_local_scope_imports}
+        )
+    }
     actual = get_flake8_linter_results(s=test_case, options=options, delimiter="\n")
     assert actual == expected
 
 
-@pytest.mark.parametrize("restrict_local_imports", [True, False])
-def test_local_import_settings_do_not_error(
+@pytest.mark.parametrize("restrict_local_scope_imports", [True, False])
+def test_local_scope_import_settings_do_not_error(
     valid_custom_import_rules_imports: str,
     get_flake8_linter_results: callable,
-    restrict_local_imports: bool,
+    restrict_local_scope_imports: bool,
 ) -> None:
     """Test local imports do not have an effect on regular import methods."""
-    options = {"checker_settings": Settings(**{"RESTRICT_LOCAL_IMPORTS": restrict_local_imports})}
+    options = {
+        "checker_settings": Settings(
+            **{"RESTRICT_LOCAL_SCOPE_IMPORTS": restrict_local_scope_imports}
+        )
+    }
     actual = get_flake8_linter_results(
         s=valid_custom_import_rules_imports, options=options, delimiter="\n"
     )


### PR DESCRIPTION
Using just local imports is confusing, because local imports also refer to packages that are available locally. This change better reflects that.

## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
