### PR TITLE
ci(python-publish): wait to publish package until after the error che…

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -26,6 +26,15 @@ jobs:
         poetry install
         pip install -e example_repos/my_base_module
 
+    # Wait for checks to succeed
+    - name: Wait for tests to succeed
+      uses: lewagon/wait-on-check-action@v1.3.1
+      with:
+        ref: ${{ github.ref }}
+        check-name: 'Run Unit Tests'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 10
+
     - name: Publish
       env:
         PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
…cks have completed

## RATIONALE

Doesn't make any sense to publish a new package before waiting all the checks have passed.

## CHANGES

- Update pythonpublish.yml

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
