### PR TITLE
test(file-utils): add missing file utils tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1443,6 +1443,23 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.11.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-mock-3.11.1.tar.gz", hash = "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"},
+    {file = "pytest_mock-3.11.1-py3-none-any.whl", hash = "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1972,4 +1989,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<=3.12"
-content-hash = "c0e4758268b676c056deddaf1fff2c67b864b2cbbd3935869cc880d0f82211f3"
+content-hash = "2063b888cd37f09b158c5d4d495dd6f4cfae7bf878e606bc0103f1e333fac3bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ tox = "^4.8.0"
 tox-gh-actions = "^3.1.3"
 coverage = { version = "^7.3.0",  extras = ["toml"] }
 covdefaults = "^2.3.0"
+pytest-mock = "^3.11.1"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/tests/utils/file_utils_test.py
+++ b/tests/utils/file_utils_test.py
@@ -4,10 +4,15 @@ To run this test file only:
 poetry run python -m pytest -vvvrca tests/utils/file_utils_test.py
 """
 import os
+import sys
 
 import pytest
 
+from flake8_custom_import_rules.utils.file_utils import convert_module_to_file_paths
+from flake8_custom_import_rules.utils.file_utils import convert_name
+from flake8_custom_import_rules.utils.file_utils import find_prefix
 from flake8_custom_import_rules.utils.file_utils import get_file_path_from_module_name
+from flake8_custom_import_rules.utils.file_utils import get_module_name_from_filename
 from flake8_custom_import_rules.utils.file_utils import get_relative_path_from_absolute_path
 
 # We get the current directory of this file.
@@ -15,6 +20,106 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 
 # We navigate to the root of the project.
 root_dir = os.path.join(current_dir, "..", "..")
+
+
+@pytest.mark.parametrize(
+    "filename, parent, normalized_path, is_file, prefix, converted_name",
+    [
+        ("test.py", os.curdir, "normalized_test.py", True, "prefix_", "prefix_test"),
+        ("not_exist.py", os.curdir, "normalized_not_exist.py", False, "", ""),
+    ],
+)
+def test_get_module_name_from_filename(
+    mocker, filename, parent, normalized_path, is_file, prefix, converted_name
+):
+    """Test get_module_name_from_filename."""
+    # Mocking normalize_path function
+    mocker.patch(
+        "flake8_custom_import_rules.utils.file_utils.normalize_path", return_value=normalized_path
+    )
+
+    # Mocking os.path.isfile function
+    mocker.patch("os.path.isfile", return_value=is_file)
+
+    # Mocking find_prefix function
+    mocker.patch("flake8_custom_import_rules.utils.file_utils.find_prefix", return_value=prefix)
+
+    # Mocking convert_name function
+    mocker.patch(
+        "flake8_custom_import_rules.utils.file_utils.convert_name", return_value=converted_name
+    )
+
+    if is_file:
+        assert get_module_name_from_filename(filename, parent) == converted_name
+    else:
+        with pytest.raises(FileNotFoundError):
+            get_module_name_from_filename(filename, parent)
+
+
+@pytest.mark.parametrize(
+    "filename, sys_path, platform, expected_prefix, expected_export_string",
+    [
+        ("/path/to/file.py", ["/path/to", "/another/path"], "linux", "/path/to", None),
+        (
+            "/no/match/file.py",
+            ["/path/to", "/another/path"],
+            "win32",
+            None,
+            "set PYTHONPATH=%PYTHONPATH%;",
+        ),
+        (
+            "/no/match/file.py",
+            ["/path/to", "/another/path"],
+            "linux",
+            None,
+            "export PYTHONPATH=$PYTHONPATH:",
+        ),
+    ],
+)
+def test_find_prefix(mocker, filename, sys_path, platform, expected_prefix, expected_export_string):
+    """Test find_prefix."""
+    mocker.patch.object(os.path, "abspath", return_value=filename)
+    mocker.patch.object(sys, "platform", platform)
+    mocker.patch.object(sys, "path", sys_path)
+
+    if expected_prefix:
+        assert find_prefix(filename) == expected_prefix
+    else:
+        with pytest.raises(ValueError) as e:
+            find_prefix(filename)
+        assert "Could not find prefix" in str(e.value)
+        assert expected_export_string in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "filename, prefix, expected_name",
+    [
+        ("/path/to/module.py", "/path/to", "module"),
+        ("/path/to/__init__.py", "/path/to", "__init__"),
+        ("/path/without/extension", "/path", "without.extension"),
+        ("/path/with/special_chars.py", "/path", "with.special_chars"),
+        ("", None, ""),  # Empty filename
+    ],
+)
+def test_convert_name(mocker, filename, prefix, expected_name):
+    """Test convert_name."""
+    mocker.patch.object(os.path, "abspath", return_value=filename)
+
+    assert convert_name(filename, prefix) == expected_name
+
+
+@pytest.mark.parametrize(
+    "module_name, expected_file_paths",
+    [
+        ("module", ["module.py", "module/__init__.py"]),
+        ("nested.module", ["nested/module.py", "nested/module/__init__.py"]),
+        ("", [".py", "/__init__.py"]),  # Empty module name
+        ("special_chars.module", ["special_chars/module.py", "special_chars/module/__init__.py"]),
+    ],
+)
+def test_convert_module_to_file_paths(module_name, expected_file_paths):
+    """Test convert_module_to_file_paths."""
+    assert convert_module_to_file_paths(module_name) == expected_file_paths
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES

Add tests for:

- from flake8_custom_import_rules.utils.file_utils import convert_module_to_file_paths
- from flake8_custom_import_rules.utils.file_utils import convert_name
- from flake8_custom_import_rules.utils.file_utils import find_prefix
- from flake8_custom_import_rules.utils.file_utils import get_module_name_from_filename

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
