### PR TITLE
fix(flake8-plugin): switch to using strings for boolean values, for s…

### DIFF
--- a/src/flake8_custom_import_rules/defaults.py
+++ b/src/flake8_custom_import_rules/defaults.py
@@ -454,7 +454,7 @@ def register_options(
         f"--{setting_key.lower()}",
         default=option_default_value,
         action="store",
-        type=type(option_default_value),
+        type=str,
         help=help_string,
         parse_from_config=True,
         comma_separated_list=not is_restriction,

--- a/src/flake8_custom_import_rules/flake8_plugin.py
+++ b/src/flake8_custom_import_rules/flake8_plugin.py
@@ -17,6 +17,7 @@ from flake8_custom_import_rules.defaults import Settings
 from flake8_custom_import_rules.defaults import register_opt
 from flake8_custom_import_rules.defaults import register_options
 from flake8_custom_import_rules.utils.option_utils import check_conflicts
+from flake8_custom_import_rules.utils.option_utils import get_bool_value
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,8 @@ class Plugin(CustomImportRulesChecker):
         # Update options with the options set in the config or on the command line
         for option_key in DEFAULT_CHECKER_SETTINGS.get_option_keys():
             option_value = getattr(parse_options, option_key.lower())
+            if option_key in STANDARD_PROJECT_LEVEL_RESTRICTION_KEYS:
+                option_value = get_bool_value(option_value)
             if option_value is not None:
                 options[option_key] = option_value
 

--- a/src/flake8_custom_import_rules/utils/option_utils.py
+++ b/src/flake8_custom_import_rules/utils/option_utils.py
@@ -61,3 +61,41 @@ def check_conflicts(settings_dict: dict) -> list | None:
 
     # If no conflicts are detected
     return conflicts or None
+
+
+def get_bool_value(value: int | str | bool) -> bool:
+    """
+    Interprets and coerces a given value to boolean type.
+
+    This function is designed to handle a variety of input types (int, str,
+    bool) and interpret them as boolean values. For example, it treats the
+    string "yes" as True and "no" as False. It raises a ValueError for
+    unexpected inputs.
+
+    Parameters
+    ----------
+    value : int | str | bool
+        The value to be interpreted as a boolean. This can be an integer
+        (0 or 1), a string ("true", "false", "yes", "no", etc.), or a boolean
+        value.
+
+    Returns
+    -------
+    bool
+        The boolean interpretation of the input value.
+
+    Raises
+    ------
+    ValueError
+        If the input value cannot be interpreted as a boolean.
+    """
+    if isinstance(value, bool):
+        return value
+
+    lowered = str(value).lower()
+    if lowered in {"false", "0", "no", "n", ""}:
+        return False
+    elif lowered in {"true", "1", "yes", "y"}:
+        return True
+    else:
+        raise ValueError(f'Cannot interpret value "{value}" as boolean')

--- a/tests/utils/option_utils_test.py
+++ b/tests/utils/option_utils_test.py
@@ -1,6 +1,9 @@
 """Test the option utils with a sample setting instance"""
+import pytest
+
 from flake8_custom_import_rules.defaults import Settings
 from flake8_custom_import_rules.utils.option_utils import check_conflicts
+from flake8_custom_import_rules.utils.option_utils import get_bool_value
 
 
 def test_check_conflicts():
@@ -21,3 +24,45 @@ def test_check_conflicts__for_none():
     """Test the check_conflicts function."""
     sample_settings = Settings()
     assert check_conflicts(sample_settings.dict) is None
+
+
+@pytest.mark.parametrize(
+    "value, expected_result",
+    [
+        # Test with boolean inputs
+        (True, True),
+        (False, False),
+        # Test with integer inputs
+        (0, False),
+        (1, True),
+        # Test with string inputs
+        ("true", True),
+        ("false", False),
+        ("yes", True),
+        ("no", False),
+        ("y", True),
+        ("n", False),
+        ("1", True),
+        ("0", False),
+        ("", False),
+    ],
+)
+def test_get_bool_value_valid_inputs(value, expected_result):
+    assert get_bool_value(value) == expected_result
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "invalid_string",
+        2,
+        -1,
+        None,
+        [],
+        {},
+    ],
+)
+def test_get_bool_value_invalid_inputs(value):
+    with pytest.raises(ValueError) as e:
+        get_bool_value(value)
+    assert f'Cannot interpret value "{value}" as boolean' in str(e.value)


### PR DESCRIPTION
…ome reason using boolean options are not working as expected

Add the following function and tests, update all relevant files:  def get_bool_value(value: int str
bool) -> bool:
    """
    Interprets and coerces a given value to boolean type.

    This function is designed to handle a variety of input types (int, str,
    bool) and interpret them as boolean values. For example, it treats the
    string "yes" as True and "no" as False. It raises a ValueError for
    unexpected inputs.

    Parameters
    ----------
    value : int
str
bool
        The value to be interpreted as a boolean. This can be an integer
        (0 or 1), a string ("true", "false", "yes", "no", etc.), or a boolean
        value.

    Returns
    -------
    bool
        The boolean interpretation of the input value.

    Raises
    ------
    ValueError
        If the input value cannot be interpreted as a boolean.
    """
    if isinstance(value, bool):
        return value

    lowered = str(value).lower()
    if lowered in {"false", "0", "no", "n", ""}:
        return False
    elif lowered in {"true", "1", "yes", "y"}:
        return True
    else:
        raise ValueError(f'Cannot interpret value "{value}" as boolean')

## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
