### PR TITLE
build(pyproject): add modulegraph = "^0.19.5" to tests section

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -483,69 +483,69 @@ files = [
 
 [[package]]
 name = "cython"
-version = "3.0.0"
+version = "3.0.1"
 description = "The Cython compiler for writing C extensions in the Python language."
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
-    {file = "Cython-3.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7c7d728e1a49ad01d41181e3a9ea80b8d14e825f4679e4dd837cbf7bca7998a5"},
-    {file = "Cython-3.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:626a4a6ef4b7ced87c348ea805488e4bd39dad9d0b39659aa9e1040b62bbfedf"},
-    {file = "Cython-3.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33c900d1ca9f622b969ac7d8fc44bdae140a4a6c7d8819413b51f3ccd0586a09"},
-    {file = "Cython-3.0.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a65bc50dc1bc2faeafd9425defbdef6a468974f5c4192497ff7f14adccfdcd32"},
-    {file = "Cython-3.0.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3b71b399b10b038b056ad12dce1e317a8aa7a96e99de7e4fa2fa5d1c9415cfb9"},
-    {file = "Cython-3.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f42f304c097cc53e9eb5f1a1d150380353d5018a3191f1b77f0de353c762181e"},
-    {file = "Cython-3.0.0-cp310-cp310-win32.whl", hash = "sha256:3e234e2549e808d9259fdb23ebcfd145be30c638c65118326ec33a8d29248dc2"},
-    {file = "Cython-3.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:829c8333195100448a23863cf64a07e1334fae6a275aefe871458937911531b6"},
-    {file = "Cython-3.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:06db81b1a01858fcc406616f8528e686ffb6cf7c3d78fb83767832bfecea8ad8"},
-    {file = "Cython-3.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c93634845238645ce7abf63a56b1c5b6248189005c7caff898fd4a0dac1c5e1e"},
-    {file = "Cython-3.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa606675c6bd23478b1d174e2a84e3c5a2c660968f97dc455afe0fae198f9d3d"},
-    {file = "Cython-3.0.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3355e6f690184f984eeb108b0f5bbc4bcf8b9444f8168933acf79603abf7baf"},
-    {file = "Cython-3.0.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93a34e1ca8afa4b7075b02ed14a7e4969256297029fb1bfd4cbe48f7290dbcff"},
-    {file = "Cython-3.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bb1165ca9e78823f9ad1efa5b3d83156f868eabd679a615d140a3021bb92cd65"},
-    {file = "Cython-3.0.0-cp311-cp311-win32.whl", hash = "sha256:2fadde1da055944f5e1e17625055f54ddd11f451889110278ef30e07bd5e1695"},
-    {file = "Cython-3.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:254ed1f03a6c237fa64f0c6e44862058de65bfa2e6a3b48ca3c205492e0653aa"},
-    {file = "Cython-3.0.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:4e212237b7531759befb92699c452cd65074a78051ae4ee36ff8b237395ecf3d"},
-    {file = "Cython-3.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f29307463eba53747b31f71394ed087e3e3e264dcc433e62de1d51f5c0c966c"},
-    {file = "Cython-3.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53328a8af0806bebbdb48a4191883b11ee9d9dfb084d84f58fa5a8ab58baefc9"},
-    {file = "Cython-3.0.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5962e70b15e863e72bed6910e8c6ffef77d36cc98e2b31c474378f3b9e49b0e3"},
-    {file = "Cython-3.0.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9e69139f4e60ab14c50767a568612ea64d6907e9c8e0289590a170eb495e005f"},
-    {file = "Cython-3.0.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c40bdbcb2286f0aeeb5df9ce53d45da2d2a9b36a16b331cd0809d212d22a8fc7"},
-    {file = "Cython-3.0.0-cp312-cp312-win32.whl", hash = "sha256:8abb8915eb2e57fa53d918afe641c05d1bcc6ed1913682ec1f28de71f4e3f398"},
-    {file = "Cython-3.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:30a4bd2481e59bd7ab2539f835b78edc19fc455811e476916f56026b93afd28b"},
-    {file = "Cython-3.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0e1e4b7e4bfbf22fecfa5b852f0e499c442d4853b7ebd33ae37cdec9826ed5d8"},
-    {file = "Cython-3.0.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b00df42cdd1a285a64491ba23de08ab14169d3257c840428d40eb7e8e9979af"},
-    {file = "Cython-3.0.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:650d03ddddc08b051b4659778733f0f173ca7d327415755c05d265a6c1ba02fb"},
-    {file = "Cython-3.0.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4965f2ebade17166f21a508d66dd60d2a0b3a3b90abe3f72003baa17ae020dd6"},
-    {file = "Cython-3.0.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:4123c8d03167803df31da6b39de167cb9c04ac0aa4e35d4e5aa9d08ad511b84d"},
-    {file = "Cython-3.0.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:296c53b6c0030cf82987eef163444e8d7631cc139d995f9d58679d9fd1ddbf31"},
-    {file = "Cython-3.0.0-cp36-cp36m-win32.whl", hash = "sha256:0d2c1e172f1c81bafcca703093608e10dc16e3e2d24c5644c17606c7fdb1792c"},
-    {file = "Cython-3.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:bc816d8eb3686d6f8d165f4156bac18c1147e1035dc28a76742d0b7fb5b7c032"},
-    {file = "Cython-3.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8d86651347bbdbac1aca1824696c5e4c0a3b162946c422edcca2be12a03744d1"},
-    {file = "Cython-3.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84176bd04ce9f3cc8799b47ec6d1959fa1ea5e71424507df7bbf0b0915bbedef"},
-    {file = "Cython-3.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35abcf07b8277ec95bbe49a07b5c8760a2d941942ccfe759a94c8d2fe5602e9f"},
-    {file = "Cython-3.0.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a44d6b9a29b2bff38bb648577b2fcf6a68cf8b1783eee89c2eb749f69494b98d"},
-    {file = "Cython-3.0.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:4dc6bbe7cf079db37f1ebb9b0f10d0d7f29e293bb8688e92d50b5ea7a91d82f3"},
-    {file = "Cython-3.0.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e28763e75e380b8be62b02266a7995a781997c97c119efbdccb8fb954bcd7574"},
-    {file = "Cython-3.0.0-cp37-cp37m-win32.whl", hash = "sha256:edae615cb4af51d5173e76ba9aea212424d025c57012e9cdf2f131f774c5ba71"},
-    {file = "Cython-3.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:20c604e974832aaf8b7a1f5455ee7274b34df62a35ee095cd7d2ed7e818e6c53"},
-    {file = "Cython-3.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c85fd2b1cbd9400d60ebe074795bb9a9188752f1612be3b35b0831a24879b91f"},
-    {file = "Cython-3.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:090256c687106932339f87f888b95f0d69c617bc9b18801555545b695d29d8ab"},
-    {file = "Cython-3.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cec2a67a0a7d9d4399758c0657ca03e5912e37218859cfbf046242cc532bfb3b"},
-    {file = "Cython-3.0.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1cdd01ce45333bc264a218c6e183700d6b998f029233f586a53c9b13455c2d2"},
-    {file = "Cython-3.0.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ecee663d2d50ca939fc5db81f2f8a219c2417b4651ad84254c50a03a9cb1aadd"},
-    {file = "Cython-3.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:30f10e79393b411af7677c270ea69807acb9fc30205c8ff25561f4deef780ec1"},
-    {file = "Cython-3.0.0-cp38-cp38-win32.whl", hash = "sha256:609777d3a7a0a23b225e84d967af4ad2485c8bdfcacef8037cf197e87d431ca0"},
-    {file = "Cython-3.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:7f4a6dfd42ae0a45797f50fc4f6add702abf46ab3e7cd61811a6c6a97a40e1a2"},
-    {file = "Cython-3.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2d8158277c8942c0b20ff4c074fe6a51c5b89e6ac60cef606818de8c92773596"},
-    {file = "Cython-3.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54e34f99b2a8c1e11478541b2822e6408c132b98b6b8f5ed89411e5e906631ea"},
-    {file = "Cython-3.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:877d1c8745df59dd2061a0636c602729e9533ba13f13aa73a498f68662e1cbde"},
-    {file = "Cython-3.0.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204690be60f0ff32eb70b04f28ef0d1e50ffd7b3f77ba06a7dc2389ee3b848e0"},
-    {file = "Cython-3.0.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:06fcb4628ccce2ba5abc8630adbeaf4016f63a359b4c6c3827b2d80e0673981c"},
-    {file = "Cython-3.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:090e24cfa31c926d0b13d8bb2ef48175acdd061ae1413343c94a2b12a4a4fa6f"},
-    {file = "Cython-3.0.0-cp39-cp39-win32.whl", hash = "sha256:4cd00f2158dc00f7f93a92444d0f663eda124c9c29bbbd658964f4e89c357fe8"},
-    {file = "Cython-3.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:5b4cc896d49ce2bae8d6a030f9a4c64965b59c38acfbf4617685e17f7fcf1731"},
-    {file = "Cython-3.0.0-py2.py3-none-any.whl", hash = "sha256:ff1aef1a03cfe293237c7a86ae9625b0411b2df30c53d1a7f29a8d381f38a1df"},
-    {file = "Cython-3.0.0.tar.gz", hash = "sha256:350b18f9673e63101dbbfcf774ee2f57c20ac4636d255741d76ca79016b1bd82"},
+    {file = "Cython-3.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:119786513aad3bd8e483040d3757f11cec808e3f9d42c965c086db7fe62b69b1"},
+    {file = "Cython-3.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5481c4ee02fd178e3ef1b2d98b0a828a79fda92998d9541088a00f70d83f9a7"},
+    {file = "Cython-3.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08dc403e6fc2b105b83759c72980bc8d7b729b03dfe94c8345a5e999dfd07d15"},
+    {file = "Cython-3.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1f7b8394cdf4d35a6d8129cdf3677642b9712793611850fbfb9cc7c4ef8d9cb"},
+    {file = "Cython-3.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f8fde8dfec6a1fe5d9d035dbb740aacc1d7aea7f0dbcaa5ce61e9a8dea0c8888"},
+    {file = "Cython-3.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f663c9206475675d5f1c086dcab0404bc7a732241f951a9c89258392601c26f8"},
+    {file = "Cython-3.0.1-cp310-cp310-win32.whl", hash = "sha256:b57d5bda3cf15e59ab46fb541d448f1b52c0d8fe8bbed7baec613537e41161eb"},
+    {file = "Cython-3.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:02e2cdaff5795875aa4441068c20a04edb727a145dd45518926f7ae692ec0061"},
+    {file = "Cython-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5e544e91efa287de31014550aa6e8525507ea6d5727c36ff5f96e9dcf9c40133"},
+    {file = "Cython-3.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182ae584dbaa6fd73161a6f8cc7d350eeefc43c091cabc2b70fa1a802a7ef729"},
+    {file = "Cython-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05dba6b214a12aa66421d810d24d0298ff37cb6036d00d4e851b61a54948540c"},
+    {file = "Cython-3.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35c28fc53745e7ebabb54d13d6cd3d3659f65ef50d324dadd9146212adb236cc"},
+    {file = "Cython-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6d9dbcecd61f4f22ae6a035628e803490af7f0e16fd91e97fec63face61873a5"},
+    {file = "Cython-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4acd382eb6d8cd34df421c42f1bfc8c7c0c38cd213fa35222a65a2a988fe50da"},
+    {file = "Cython-3.0.1-cp311-cp311-win32.whl", hash = "sha256:c43adbc5a3a1d678314734f69dba3eb4f24438ba668e08a438b8067ac5a6494e"},
+    {file = "Cython-3.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:35701606862989d5db641cf8cb85f62eaab9beaafb09a102839aebe5a70a1060"},
+    {file = "Cython-3.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9dbdb0019304ec84c7209a967043fc4923ed2d911a37ed695c3d1548c99b1285"},
+    {file = "Cython-3.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92f0dda50c11770673c332603b52ce0cb4abf32f2562e53dbdc4b674b6be7faa"},
+    {file = "Cython-3.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6f7ead11cfb2d6c6dd7a1fd1987ce221c5c1061b47d747b0bb84b5704045cf9"},
+    {file = "Cython-3.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5936dd43207a3f0269d033463195e201072b9b594c9693ff142985c0c33cd2d2"},
+    {file = "Cython-3.0.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:768044473afd9fca3ba65d92deb80f16aa10d2776c9c2a8f667dbb480a58c528"},
+    {file = "Cython-3.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:79f3ea7233e8a8856e57acdb7a30e8548009732649ffabe94049b35e2e5d7b8a"},
+    {file = "Cython-3.0.1-cp312-cp312-win32.whl", hash = "sha256:b0917b84af48616124dfead2235b36c64c0d024c4d19cefa1a5da2f106a0854a"},
+    {file = "Cython-3.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:bde58bda00d4689eb51ad3129873b09c695a64d3b6b8573cbc450e177a87173a"},
+    {file = "Cython-3.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e69223fb6b99addff8b6d8a3e9f5ae044438bbf48dc08a3495eb99b13e62273c"},
+    {file = "Cython-3.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a51fa13b5fcace8389888542b7bf63728898a9fefcb471cbf9f7736ce057d8a"},
+    {file = "Cython-3.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3194c330dc4c07c01f7d802868960ff053ef5c026aea17e03b025e307c9d94fe"},
+    {file = "Cython-3.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49f13d342a810947685759597013e1e4fdc9875d74372fa6121cb190913100d4"},
+    {file = "Cython-3.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:d9a510157a454bec22752713465d1698098b99351bc41be8938f3d526286aa6f"},
+    {file = "Cython-3.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:6bfdce6a65b8587ed992af912107d9cf047ed14bfdddcba6bd7917feb93cb441"},
+    {file = "Cython-3.0.1-cp36-cp36m-win32.whl", hash = "sha256:b76e3237b7c6e1cb53af2223c20f5b51ea1cc40d77966eb121187825657fb9cf"},
+    {file = "Cython-3.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:db53e83bc793538ed00e8fe04d2a2469c8f18f636f3e9b26564b51d6b384015c"},
+    {file = "Cython-3.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e7d42293809ff45d7743fb81bda64ecdb24a269d5bfcbd22cf74f2b8d112039f"},
+    {file = "Cython-3.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8f0f4fc248e742d6a17fdbb646fff21d99e21b7ce5180f00dcf8a9588fbfb73"},
+    {file = "Cython-3.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e88759313bffc67616ee10ff142a395b19a48789a5e20880e8fc8fd3208ab37"},
+    {file = "Cython-3.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da7f41b170a70b5c0172795a487c7301b43c136918b23724aec8d1388cee668f"},
+    {file = "Cython-3.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:db6a823a86a10532934f83b6445f07634b2ad872fe52577ab0861a0f074e3036"},
+    {file = "Cython-3.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d322561a852fa77b4b47668b12265f4a6ae7aed232aad2e3d52379e16c4e1ece"},
+    {file = "Cython-3.0.1-cp37-cp37m-win32.whl", hash = "sha256:f02fcd11da42739a6fe3b5e1a3b21e644e10d02fb47757b1be239cabe3312d51"},
+    {file = "Cython-3.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:e02c1c06d2b0138effead19c6c352ac1b99b2c431d97b6379ff4e17c9348bf61"},
+    {file = "Cython-3.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:53883e5092eff175aea2811e987ae930723ee4657bd470f549b63c5fd738ada3"},
+    {file = "Cython-3.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:402b05a42a516a53912d980de644fdc30b6702e5f8ebf984276e162cac4a12c5"},
+    {file = "Cython-3.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fba7d0d5978a5ddb5e3cd59ce2b5bfeace6cabdad8aa7b5f740028e8b3126b88"},
+    {file = "Cython-3.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:346232ecb90ade8ff456361b58e9ca21cf672a4191e26ae498993975980a615b"},
+    {file = "Cython-3.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:d12ab154d8bf68eadea69ff24f1bc90d7a332b20da4d9a3a82e737f6fc06091a"},
+    {file = "Cython-3.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:cf6c8c05075b510d4f53127a8239c43a5f148e1ba1c479cb3e21e15112c533cf"},
+    {file = "Cython-3.0.1-cp38-cp38-win32.whl", hash = "sha256:9a12ac8f9cc2e8ed191f7b18e8661cd64d7ff2299e4566abc8c03e03721ba6ca"},
+    {file = "Cython-3.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:dc65a9cdeb29b553bfcdc90499b672a75bc85ed7d4b212018e513463244f59ae"},
+    {file = "Cython-3.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:934f236a1f002705f012b7ba7b068a092c0023a7b965d3139c8dc7e34f166dd1"},
+    {file = "Cython-3.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5ad08fed2444a0168dbfe0589cd711091adf38d19ea4421ebe92886bf4e0c22"},
+    {file = "Cython-3.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff571d41e2673678929ad1f5fee68e1757bd8e42c0082c3359138da56fc25263"},
+    {file = "Cython-3.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:137ec3f7abda49f53621c8c7f427d93ad5ac33a5f4e112e04594c1aad0bd0613"},
+    {file = "Cython-3.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:fc1452139e1eb044b6e906a71c92e5580fec4deabe75cb440324d17b1163b038"},
+    {file = "Cython-3.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:720e72474c55d33c245e0280ecb4b604dd301ed3851c78cede932f2c3d074224"},
+    {file = "Cython-3.0.1-cp39-cp39-win32.whl", hash = "sha256:d63f67696df2caeac5c57a12485ff4c7f377bead430c3654145b57bc105ba3c6"},
+    {file = "Cython-3.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:00f7378e1cd1c22076922489cb628ce63301c018231c67f1389cef803cc2b586"},
+    {file = "Cython-3.0.1-py2.py3-none-any.whl", hash = "sha256:7894efe3b47231bfdf8be1a8a2852a2b07dd83cad16bbdf666591894198c82dd"},
+    {file = "Cython-3.0.1.tar.gz", hash = "sha256:f3e49c4eaaa11345486ac0fa2b350636e44a4b45bd7521a6b133924c5ff20bba"},
 ]
 
 [[package]]
@@ -659,13 +659,13 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 
 [[package]]
 name = "griffe"
-version = "0.34.0"
+version = "0.35.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.34.0-py3-none-any.whl", hash = "sha256:d8bca9bd4a0880e7f71dc152de4222171d941a32b5504d77450a71a7908dfc1d"},
-    {file = "griffe-0.34.0.tar.gz", hash = "sha256:48c667ad51a7f756238f798866203aeb8f9fa02d4192e25970f57f813bb37f26"},
+    {file = "griffe-0.35.0-py3-none-any.whl", hash = "sha256:52b1dc86dfca6db5877d65a07997f8363f61f14266064cf1cae41b70aac9f395"},
+    {file = "griffe-0.35.0.tar.gz", hash = "sha256:d313f102da3d155fe0a3d284acb0fc93059ee6788903a2e983eb4f64a713fac1"},
 ]
 
 [package.dependencies]
@@ -1190,17 +1190,17 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.5.0"
+version = "1.5.2"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings_python-1.5.0-py3-none-any.whl", hash = "sha256:f95055a23c42dd6c861f8e10201ada246c5c34def22a74dd5f73ead59c0d8958"},
-    {file = "mkdocstrings_python-1.5.0.tar.gz", hash = "sha256:1b56a66b600df09b3bc787f27b86592fb4cb02e62e08e68053538725a0489175"},
+    {file = "mkdocstrings_python-1.5.2-py3-none-any.whl", hash = "sha256:ed37ca6d216986e2ac3530c19c3e7be381d1e3d09ea414e4ff467d6fd2cbd9c1"},
+    {file = "mkdocstrings_python-1.5.2.tar.gz", hash = "sha256:81eb4a93bc454a253daf247d1a11397c435d641c64fa165324c17c06170b1dfb"},
 ]
 
 [package.dependencies]
-griffe = ">=0.33"
+griffe = ">=0.35"
 mkdocstrings = ">=0.20"
 
 [[package]]
@@ -2239,4 +2239,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<=3.12"
-content-hash = "18e9e018b303800a7c0eb134bfa1df225c1e97a2995e17da4fd1c40eca02ce51"
+content-hash = "16aedee11a102ee836f5ab1d3b242369ab12bc5a726a71a4eb9b69b52efda110"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,10 @@ cython = "^3.0.0"
 cmake = "^3.27.2"
 tryceratops = "^2.3.2"
 tomark = "^0.1.4"
-modulegraph = "^0.19.5"
 
 
 [tool.poetry.group.test.dependencies]
+modulegraph = "^0.19.5"
 pytest = "^7.4.0"
 pytest-cov = "^4.1.0"
 toml = "^0.10.2"


### PR DESCRIPTION
This module is needed during tests, but not for the package, originally in dev, but I don't want to install all those packages during the test actions.

## CHANGES

- update `pyproject.toml`

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
