### PR TITLE
fix(file-utils): fix could not find prefix for file, adding find pref…

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "assets"
+  - "dependency_wheel"
+  - "example_repos"
+  - "scripts"
+  - "tests"

--- a/src/flake8_custom_import_rules/utils/file_utils.py
+++ b/src/flake8_custom_import_rules/utils/file_utils.py
@@ -56,7 +56,30 @@ def find_prefix(filename: str) -> str:
     matches = (path for path in sys.path if filename.startswith(path))
     try:
         return max(matches, key=len)
+    except ValueError:
+        # Add the current working directory to sys.path
+        sys.path.append(os.getcwd())
 
+    return find_prefix_again(filename)
+
+
+def find_prefix_again(filename: str) -> str:
+    """
+    Try to find the appropriate module prefix string for the filename again.
+
+    Parameters
+    ----------
+    filename : str
+        The filename to find the prefix for.
+
+    Returns
+    -------
+    str
+    """
+    # Try to find the prefix again
+    matches = (path for path in sys.path if filename.startswith(path))
+    try:
+        return max(matches, key=len)
     except ValueError as e:
         machine = sys.platform
         if machine in {"win32", "cygwin"}:


### PR DESCRIPTION
…ix again function and automatically adding to the system path

This code will first try to find the prefix in the current sys.path. If it fails, it will add the current working directory to sys.path and try to find the prefix again. If it still fails, it will raise a ValueError with instructions on how to add the current working directory to sys.path manually.

## RATIONALE

A short description of the changes in this pull request. If the pull request is related to an open issue, mention it here.

## CHANGES

Update the following functions

```python
def find_prefix(filename: str) -> str:
    """
    Find the appropriate module prefix string for the filename.

    Parameters
    ----------
    filename : str
        The filename to find the prefix for.

    Returns
    -------
    str
    """
    filename = os.path.abspath(filename)
    logger.debug(f"filename in find_prefix: {filename}")

    # Find the deepest path
    matches = (path for path in sys.path if filename.startswith(path))
    try:
        return max(matches, key=len)
    except ValueError:
        # Add the current working directory to sys.path
        sys.path.append(os.getcwd())

    return find_prefix_again(filename)


def find_prefix_again(filename: str) -> str:
    """
    Try to find the appropriate module prefix string for the filename again.

    Parameters
    ----------
    filename : str
        The filename to find the prefix for.

    Returns
    -------
    str
    """
    # Try to find the prefix again
    matches = (path for path in sys.path if filename.startswith(path))
    try:
        return max(matches, key=len)
    except ValueError as e:
        machine = sys.platform
        if machine in {"win32", "cygwin"}:
            export_string = f"set PYTHONPATH=%PYTHONPATH%;{os.getcwd()}"
        else:
            export_string = f"export PYTHONPATH=$PYTHONPATH:{os.getcwd()}"

        raise ValueError(
            f"Could not find prefix for {filename}. "
            f"To fix this, add the current working directory containing {filename} "
            f"to sys.path using `{export_string}`."
        ) from e
        # raise ValueError(f"sys.path {sys.path}") from e
```

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


## CHECKLIST

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
